### PR TITLE
fix: correct session key format for multi-agent OpenClaw deployments

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -677,7 +677,7 @@ export class OpenClawAgentExecutor implements AgentExecutor {
       // 1. Session reuse across messages in the same A2A context (conversation continuity)
       // 2. Isolation between different A2A contexts (no cross-contamination)
       // The gateway `agent` RPC auto-creates the session if it doesn't exist.
-      const sessionKey = `a2a:${agentId}:${contextId}`;
+      const sessionKey = `agent:${agentId}:a2a:${contextId}`;
 
       const runId = uuidv4();
       const agentParams: Record<string, unknown> = {


### PR DESCRIPTION
Session key was using 'a2a:${agentId}:${contextId}' format which is incompatible with OpenClaw gateway RPC. The gateway parses agent ID from session keys using 'agent:' prefix convention. Using the wrong prefix causes fallback to the plugin's own session agent ('main'), resulting in mismatch errors on any deployment where defaultAgentId differs from 'main'.

Fix: change to 'agent:${agentId}:a2a:${contextId}' to align with OpenClaw's session key convention while preserving A2A namespace.

Verified on OpenClaw 2026.3.7 + Ubuntu 24.04 multi-agent setup.