### PR TITLE
improve: zero-config install + fix session key for multi-agent routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,35 @@ An [OpenClaw](https://github.com/openclaw/openclaw) plugin that implements the [
 
 ## Installation
 
+### Quick Start (zero-config)
+
+The plugin ships with sensible defaults — you can install and load it **without any manual configuration**:
+
+```bash
+# Clone
+mkdir -p ~/.openclaw/workspace/plugins
+cd ~/.openclaw/workspace/plugins
+git clone https://github.com/win4r/openclaw-a2a-gateway.git a2a-gateway
+cd a2a-gateway
+npm install --production
+
+# Register & enable
+openclaw plugins install ~/.openclaw/workspace/plugins/a2a-gateway
+
+# Restart
+openclaw gateway restart
+
+# Verify
+openclaw plugins list          # should show a2a-gateway as loaded
+curl -s http://localhost:18800/.well-known/agent-card.json | python3 -m json.tool
+```
+
+The plugin will start with the default Agent Card (`name: "OpenClaw A2A Gateway"`, `skills: [chat]`). You can customize it later — see [Configure the Agent Card](#3-configure-the-agent-card) below.
+
+### Step-by-Step Installation
+
+If you prefer manual control or need to keep existing plugins in your config:
+
 ### 1. Clone the plugin
 
 ```bash
@@ -58,7 +87,15 @@ openclaw config set plugins.entries.a2a-gateway.enabled true
 
 ### 3. Configure the Agent Card
 
-Every A2A agent needs an Agent Card that describes itself:
+Every A2A agent needs an Agent Card that describes itself. If you skip this step, the plugin uses these defaults:
+
+| Field | Default |
+|-------|---------|
+| `agentCard.name` | `OpenClaw A2A Gateway` |
+| `agentCard.description` | `A2A bridge for OpenClaw agents` |
+| `agentCard.skills` | `[{"id":"chat","name":"chat","description":"Chat bridge"}]` |
+
+To customize:
 
 ```bash
 openclaw config set plugins.entries.a2a-gateway.config.agentCard.name 'My Agent'
@@ -329,10 +366,10 @@ node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
 
 | Path | Type | Default | Description |
 |------|------|---------|-------------|
-| `agentCard.name` | string | *required* | Display name for this agent |
-| `agentCard.description` | string | — | Human-readable description |
+| `agentCard.name` | string | `OpenClaw A2A Gateway` | Display name for this agent |
+| `agentCard.description` | string | `A2A bridge for OpenClaw agents` | Human-readable description |
 | `agentCard.url` | string | auto | JSON-RPC endpoint URL |
-| `agentCard.skills` | array | *required* | List of skills this agent offers |
+| `agentCard.skills` | array | `[{chat}]` | List of skills this agent offers |
 | `server.host` | string | `0.0.0.0` | Bind address |
 | `server.port` | number | `18800` | A2A server port |
 | `peers` | array | `[]` | List of peer agents |

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,6 +30,35 @@
 
 ## 安装步骤
 
+### 快速开始（零配置）
+
+插件内置了合理的默认值 —— **无需任何手动配置**即可安装并加载：
+
+```bash
+# 克隆
+mkdir -p ~/.openclaw/workspace/plugins
+cd ~/.openclaw/workspace/plugins
+git clone https://github.com/win4r/openclaw-a2a-gateway.git a2a-gateway
+cd a2a-gateway
+npm install --production
+
+# 注册并启用
+openclaw plugins install ~/.openclaw/workspace/plugins/a2a-gateway
+
+# 重启
+openclaw gateway restart
+
+# 验证
+openclaw plugins list          # 应该能看到 a2a-gateway 已加载
+curl -s http://localhost:18800/.well-known/agent-card.json | python3 -m json.tool
+```
+
+插件会以默认 Agent Card 启动（`name: "OpenClaw A2A Gateway"`，`skills: [chat]`）。后续可按需自定义 —— 见下方 [配置 Agent Card](#3-配置-agent-card)。
+
+### 分步安装
+
+如果你需要手动控制或保留已有插件配置：
+
 ### 1. 克隆插件
 
 ```bash
@@ -58,7 +87,15 @@ openclaw config set plugins.entries.a2a-gateway.enabled true
 
 ### 3. 配置 Agent Card
 
-每个 A2A Agent 都需要一个描述自身的 Agent Card：
+每个 A2A Agent 都需要一个描述自身的 Agent Card。如果跳过此步骤，插件使用以下默认值：
+
+| 字段 | 默认值 |
+|------|--------|
+| `agentCard.name` | `OpenClaw A2A Gateway` |
+| `agentCard.description` | `A2A bridge for OpenClaw agents` |
+| `agentCard.skills` | `[{"id":"chat","name":"chat","description":"Chat bridge"}]` |
+
+自定义配置：
 
 ```bash
 openclaw config set plugins.entries.a2a-gateway.config.agentCard.name '我的Agent'
@@ -327,10 +364,10 @@ node <插件路径>/skill/scripts/a2a-send.mjs \
 
 | 配置路径 | 类型 | 默认值 | 说明 |
 |---------|------|--------|------|
-| `agentCard.name` | string | *必填* | Agent 显示名称 |
-| `agentCard.description` | string | — | 人类可读的描述 |
+| `agentCard.name` | string | `OpenClaw A2A Gateway` | Agent 显示名称 |
+| `agentCard.description` | string | `A2A bridge for OpenClaw agents` | 人类可读的描述 |
 | `agentCard.url` | string | 自动 | JSON-RPC 端点 URL |
-| `agentCard.skills` | array | *必填* | Agent 提供的技能列表 |
+| `agentCard.skills` | array | `[{chat}]` | Agent 提供的技能列表 |
 | `server.host` | string | `0.0.0.0` | 绑定地址 |
 | `server.port` | number | `18800` | A2A 服务端口 |
 | `peers` | array | `[]` | 对等 Agent 列表 |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,6 +3,13 @@
   "name": "A2A Gateway",
   "description": "OpenClaw A2A v0.3.0 gateway with Agent Card, JSON-RPC, and REST endpoints",
   "version": "1.0.0",
+  "defaultConfig": {
+    "agentCard": {
+      "name": "OpenClaw A2A Gateway",
+      "description": "A2A bridge for OpenClaw agents",
+      "skills": [{ "id": "chat", "name": "chat", "description": "Chat bridge" }]
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -31,8 +38,7 @@
               ]
             }
           }
-        },
-        "required": ["name", "skills"]
+        }
       },
       "server": {
         "type": "object",
@@ -99,8 +105,7 @@
           }
         }
       }
-    },
-    "required": ["agentCard"]
+    }
   },
   "uiHints": {
     "peers": {

--- a/src/agent-card.ts
+++ b/src/agent-card.ts
@@ -21,14 +21,17 @@ function toSkill(entry: string | { id?: string; name: string; description?: stri
 }
 
 export function buildAgentCard(config: GatewayConfig): AgentCard {
-  const configuredUrl = config.agentCard.url;
-  const fallbackHost = config.server.host === "0.0.0.0" ? "localhost" : config.server.host;
-  const fallbackUrl = `http://${fallbackHost}:${config.server.port}/a2a/jsonrpc`;
+  const agentCard = config.agentCard || ({} as GatewayConfig["agentCard"]);
+  const server = config.server || { host: "0.0.0.0", port: 18800 };
+  const configuredUrl = agentCard.url;
+  const fallbackHost = server.host === "0.0.0.0" ? "localhost" : server.host;
+  const fallbackUrl = `http://${fallbackHost}:${server.port}/a2a/jsonrpc`;
 
   const securitySchemes: AgentCard["securitySchemes"] = {};
   const security: AgentCard["security"] = [];
 
-  if (config.security.inboundAuth === "bearer") {
+  const security_ = config.security || { inboundAuth: "none", token: "" };
+  if (security_.inboundAuth === "bearer") {
     securitySchemes["bearer"] = {
       type: "http",
       scheme: "bearer",
@@ -36,18 +39,18 @@ export function buildAgentCard(config: GatewayConfig): AgentCard {
     security.push({ bearer: [] });
   }
 
-  const grpcPort = config.server.port + 1;
-  const grpcHost = config.server.host === "0.0.0.0"
+  const grpcPort = server.port + 1;
+  const grpcHost = server.host === "0.0.0.0"
     ? (configuredUrl ? new URL(configuredUrl).hostname : "localhost")
-    : config.server.host;
+    : server.host;
 
   return {
     protocolVersion: "0.3.0",
     version: "1.0.0",
-    name: config.agentCard.name,
-    description: config.agentCard.description || "A2A bridge for OpenClaw agents",
+    name: agentCard.name || "OpenClaw A2A Gateway",
+    description: agentCard.description || "A2A bridge for OpenClaw agents",
     url: configuredUrl || fallbackUrl,
-    skills: config.agentCard.skills.map((entry, index) => toSkill(entry, index)),
+    skills: (agentCard.skills || []).map((entry, index) => toSkill(entry, index)),
     capabilities: {
       streaming: false,
       pushNotifications: false,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -677,7 +677,7 @@ export class OpenClawAgentExecutor implements AgentExecutor {
       // 1. Session reuse across messages in the same A2A context (conversation continuity)
       // 2. Isolation between different A2A contexts (no cross-contamination)
       // The gateway `agent` RPC auto-creates the session if it doesn't exist.
-      const sessionKey = `a2a:${agentId}:${contextId}`;
+      const sessionKey = `agent:${agentId}:a2a:${contextId}`;
 
       const runId = uuidv4();
       const agentParams: Record<string, unknown> = {

--- a/tests/a2a-gateway.test.ts
+++ b/tests/a2a-gateway.test.ts
@@ -87,6 +87,104 @@ function makeConfig(overrides: Record<string, unknown> = {}): Record<string, unk
   };
 }
 
+/**
+ * Create a mock WebSocket class that simulates the OpenClaw gateway protocol.
+ * Includes connect.challenge event (required since executor uses challenge-based connect).
+ * Optional onAgent callback to inspect agent RPC params.
+ */
+function createMockWebSocketClass(options?: {
+  onAgent?: (params: Record<string, unknown>) => void;
+  agentResponseText?: string;
+}) {
+  const agentResponseText = options?.agentResponseText ?? "Gateway response";
+
+  return class MockGatewaySocket {
+    readyState = 0;
+    private readonly listeners = new Map<string, Set<(event: any) => void>>();
+
+    constructor(_url: string) {
+      this.listeners.set("open", new Set());
+      this.listeners.set("message", new Set());
+      this.listeners.set("error", new Set());
+      this.listeners.set("close", new Set());
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit("open", {});
+        // OpenClaw gateway sends connect.challenge after socket opens
+        queueMicrotask(() => {
+          this.emit("message", {
+            data: JSON.stringify({
+              type: "event",
+              event: "connect.challenge",
+              payload: { nonce: "test-nonce-123" },
+            }),
+          });
+        });
+      });
+    }
+
+    send(data: string): void {
+      const frame = JSON.parse(data) as { id: string; method: string; params?: any };
+      if (frame.method === "connect") {
+        this.respond(frame.id, true, { status: "ok" });
+        return;
+      }
+      if (frame.method === "sessions.resolve") {
+        this.respond(frame.id, true, { key: "session-1" });
+        return;
+      }
+      if (frame.method === "agent") {
+        options?.onAgent?.(frame.params || {});
+        this.respond(frame.id, true, { status: "accepted" });
+        this.respond(frame.id, true, {
+          status: "ok",
+          result: {
+            payloads: [{ kind: "text", text: agentResponseText }],
+          },
+        });
+        return;
+      }
+      this.respond(frame.id, false, null, { message: `unsupported method ${frame.method}` });
+    }
+
+    close(): void {
+      this.readyState = 3;
+      this.emit("close", {});
+    }
+
+    addEventListener(type: string, listener: (event: any) => void): void {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type)?.add(listener);
+    }
+
+    removeEventListener(type: string, listener: (event: any) => void): void {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    private respond(id: string, ok: boolean, payload?: unknown, error?: unknown): void {
+      queueMicrotask(() => {
+        this.emit("message", {
+          data: JSON.stringify({
+            type: "res",
+            id,
+            ok,
+            payload,
+            error,
+          }),
+        });
+      });
+    }
+
+    private emit(type: string, event: unknown): void {
+      for (const listener of this.listeners.get(type) || []) {
+        listener(event);
+      }
+    }
+  };
+}
+
 async function invokeGatewayMethod(
   harness: Harness,
   methodName: string,
@@ -111,6 +209,98 @@ async function invokeGatewayMethod(
     });
   });
 }
+
+describe("zero-config install (issue #7)", () => {
+  it("registers plugin with empty config (no agentCard provided)", () => {
+    // Simulates what happens when a user runs `openclaw plugins install` without
+    // providing any agentCard config. The plugin should use built-in defaults.
+    const harness = createHarness({});
+    assert.ok(harness.service, "service should be registered even with empty config");
+    assert.ok(harness.methods.has("a2a.send"), "a2a.send method should be registered");
+  });
+
+  it("builds Agent Card with defaults when agentCard fields are missing", () => {
+    // Simulate: user provides agentCard object but omits name/skills/description
+    const minimalConfig = makeConfig({
+      agentCard: {},
+    });
+    const card = buildAgentCard(minimalConfig as unknown as GatewayConfig) as Record<string, unknown>;
+    assert.equal(card.name, "OpenClaw A2A Gateway", "should use default name");
+    assert.equal(card.protocolVersion, "0.3.0");
+    assert.equal(card.description, "A2A bridge for OpenClaw agents");
+  });
+});
+
+describe("session key format (PR #9, issue #8)", () => {
+  it("session key uses agent: prefix for OpenClaw gateway compatibility", async () => {
+    const api = {
+      config: { gateway: { port: 18789 } },
+      logger: {
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+      },
+    } as any;
+
+    let capturedSessionKey = "";
+
+    const MockWS = createMockWebSocketClass({
+      onAgent: (params) => {
+        if (params.sessionKey) {
+          capturedSessionKey = params.sessionKey as string;
+        }
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+
+      await executor.execute(
+        {
+          taskId: "task-sk",
+          contextId: "ctx-sk",
+          userMessage: {
+            messageId: "msg-sk",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test session key" }],
+          },
+        } as any,
+        {
+          publish() {},
+          finished() {},
+        } as any
+      );
+
+      // The key MUST start with "agent:" for OpenClaw gateway to parse agentId correctly.
+      assert.ok(
+        capturedSessionKey.startsWith("agent:"),
+        `session key should start with "agent:" but got "${capturedSessionKey}"`
+      );
+      // Should contain the agentId
+      assert.ok(
+        capturedSessionKey.includes("writer-agent"),
+        `session key should contain agentId "writer-agent"`
+      );
+      // Should contain A2A namespace
+      assert.ok(
+        capturedSessionKey.includes("a2a:"),
+        `session key should contain "a2a:" namespace`
+      );
+      // Full format: agent:{agentId}:a2a:{contextId}
+      assert.equal(
+        capturedSessionKey,
+        "agent:writer-agent:a2a:ctx-sk",
+        "session key should follow agent:{agentId}:a2a:{contextId} format"
+      );
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+});
 
 describe("a2a-gateway plugin", () => {
   it("builds an Agent Card with protocolVersion 0.3.0 and required fields", async () => {
@@ -138,83 +328,10 @@ describe("a2a-gateway plugin", () => {
       },
     } as any;
 
-    class MockGatewaySocket {
-      readyState = 0;
-      private readonly listeners = new Map<string, Set<(event: any) => void>>();
-
-      constructor(_url: string) {
-        this.listeners.set("open", new Set());
-        this.listeners.set("message", new Set());
-        this.listeners.set("error", new Set());
-        this.listeners.set("close", new Set());
-        queueMicrotask(() => {
-          this.readyState = 1;
-          this.emit("open", {});
-        });
-      }
-
-      send(data: string): void {
-        const frame = JSON.parse(data) as { id: string; method: string };
-        if (frame.method === "connect") {
-          this.respond(frame.id, true, { status: "ok" });
-          return;
-        }
-        if (frame.method === "sessions.resolve") {
-          this.respond(frame.id, true, { key: "session-1" });
-          return;
-        }
-        if (frame.method === "agent") {
-          this.respond(frame.id, true, { status: "accepted" });
-          this.respond(frame.id, true, {
-            status: "ok",
-            result: {
-              payloads: [{ kind: "text", text: "Gateway response" }],
-            },
-          });
-          return;
-        }
-        this.respond(frame.id, false, null, { message: `unsupported method ${frame.method}` });
-      }
-
-      close(): void {
-        this.readyState = 3;
-        this.emit("close", {});
-      }
-
-      addEventListener(type: string, listener: (event: any) => void): void {
-        if (!this.listeners.has(type)) {
-          this.listeners.set(type, new Set());
-        }
-        this.listeners.get(type)?.add(listener);
-      }
-
-      removeEventListener(type: string, listener: (event: any) => void): void {
-        this.listeners.get(type)?.delete(listener);
-      }
-
-      private respond(id: string, ok: boolean, payload?: unknown, error?: unknown): void {
-        queueMicrotask(() => {
-          this.emit("message", {
-            data: JSON.stringify({
-              type: "res",
-              id,
-              ok,
-              payload,
-              error,
-            }),
-          });
-        });
-      }
-
-      private emit(type: string, event: unknown): void {
-        for (const listener of this.listeners.get(type) || []) {
-          listener(event);
-        }
-      }
-    }
+    const MockWS = createMockWebSocketClass();
 
     const originalWebSocket = (globalThis as any).WebSocket;
-    (globalThis as any).WebSocket = MockGatewaySocket;
+    (globalThis as any).WebSocket = MockWS;
 
     try {
       const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
@@ -295,21 +412,13 @@ describe("a2a-gateway plugin", () => {
         } as any
       );
 
-      // No legacy dispatch path.
-      assert.equal(true, true);
       assert.equal(finishedCalled, true);
 
       const finalTask = published[published.length - 1] as Record<string, unknown>;
       assert.equal(finalTask.kind, "task");
       const status = finalTask.status as Record<string, unknown>;
-      assert.equal(status.state, "completed");
-
-      const message = status.message as Record<string, unknown>;
-      const parts = message.parts as Array<Record<string, unknown>>;
-      assert.equal(
-        parts[0].text,
-        "Request accepted (no agent dispatch available)",
-      );
+      // When WebSocket is unavailable, executor publishes a failed state
+      assert.equal(status.state, "failed");
     } finally {
       (globalThis as any).WebSocket = originalWebSocket;
     }


### PR DESCRIPTION
1. Zero-config install (closes #7):
   - Remove required constraint on agentCard in configSchema
   - Add defaultConfig with sensible defaults (name, description, skills)
   - Harden buildAgentCard() against missing/empty config fields
   - Add Quick Start section to README and README_CN

2. Session key fix (closes #8, supersedes #9):
   - Change session key format from a2a:{agentId}:{contextId} to agent:{agentId}:a2a:{contextId} for OpenClaw gateway compatibility
   - Credit: @DashBot-0001 identified and reported this issue

3. Test improvements:
   - Add zero-config and session key format tests
   - Fix mock WebSocket to include connect.challenge event
   - Fix fallback test assertion (failed vs completed)
   - Extract shared mock factory for DRY test setup

Tested on OpenClaw 2026.3.7 with 7-agent AntiBot + 3-agent Ruizhi (Discord end-to-end verified both directions).