### PR TITLE
feat: P1 multi-round conversation support

### DIFF
--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -5,6 +5,7 @@
  * Usage:
  *   node a2a-send.mjs --peer-url <PEER_BASE_URL> --token <TOKEN> --message "Hello!"
  *   node a2a-send.mjs --peer-url http://100.76.43.74:18800 --token abc123 --message "What is your name?"
+ *   node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message "Follow up" --task-id <TASK_ID> --context-id <CONTEXT_ID>
  *
  * Async task mode (recommended for long-running prompts):
  *   node a2a-send.mjs --peer-url <URL> --token <TOKEN> --non-blocking --wait --message "..."
@@ -13,10 +14,13 @@
  *   --peer-url <url>        Peer base URL, e.g. http://100.76.43.74:18800
  *   --token <token>         Bearer token for the peer inbound auth
  *   --message <text>        Text to send
+ *   --task-id <id>          Reuse an existing A2A task for follow-up turns
+ *   --context-id <id>       Reuse an existing A2A context for multi-round conversation routing
  *   --non-blocking          Send with configuration.blocking=false (returns quickly with a Task)
  *   --wait                  When non-blocking, poll tasks/get until terminal state
  *   --timeout-ms <ms>       Max wait time for --wait (default: 600000)
  *   --poll-ms <ms>          Poll interval for --wait (default: 1000)
+ *   --help                  Show this help text
  *
  * Optional (OpenClaw extension):
  *   --agent-id <agentId>    Route the inbound A2A request to a specific OpenClaw agentId on the peer.
@@ -37,10 +41,11 @@ import {
 import { GrpcTransportFactory } from "@a2a-js/sdk/client/grpc";
 import { randomUUID } from "node:crypto";
 
+const USAGE = `Usage: node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message <TEXT> [--task-id <id>] [--context-id <id>] [--non-blocking] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>] [--help]`;
+
 function usageAndExit(code = 1) {
-  console.error(
-    "Usage: node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message <TEXT> [--non-blocking] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>]"
-  );
+  const stream = code === 0 ? console.log : console.error;
+  stream(USAGE);
   process.exit(code);
 }
 
@@ -61,6 +66,10 @@ function parseArgs() {
     } else {
       opts[key] = true;
     }
+  }
+
+  if (opts.help || opts.h) {
+    usageAndExit(0);
   }
 
   const peerUrl = String(opts["peer-url"] || opts.peerUrl || "").trim();
@@ -93,6 +102,8 @@ async function main() {
   const token = typeof opts.token === "string" ? opts.token : "";
   const message = opts.message;
   const targetAgentId = (opts["agent-id"] || opts.agentId || "").toString().trim();
+  const continuationTaskId = (opts["task-id"] || opts.taskId || "").toString().trim().slice(0, 256);
+  const continuationContextId = (opts["context-id"] || opts.contextId || "").toString().trim().slice(0, 256);
 
   const nonBlocking = Boolean(opts["non-blocking"] || opts.nonBlocking);
   const wait = Boolean(opts.wait);
@@ -153,6 +164,8 @@ async function main() {
     messageId: randomUUID(),
     role: "user",
     parts: [{ kind: "text", text: message }],
+    ...(continuationTaskId ? { taskId: continuationTaskId } : {}),
+    ...(continuationContextId ? { contextId: continuationContextId } : {}),
     ...(targetAgentId ? { agentId: targetAgentId } : {}),
   };
 
@@ -165,6 +178,19 @@ async function main() {
 
   const result = await client.sendMessage(sendParams, requestOptions);
 
+  const printTaskHandle = (task) => {
+    if (!task || typeof task !== "object") return;
+    const responseTaskId = typeof task.id === "string" ? task.id : typeof task.taskId === "string" ? task.taskId : "";
+    if (!responseTaskId) return;
+    const responseContextId =
+      typeof task.contextId === "string"
+        ? task.contextId
+        : typeof continuationContextId === "string" && continuationContextId
+          ? continuationContextId
+          : "";
+    console.log(`[task] id=${responseTaskId} contextId=${responseContextId || "-"}`);
+  };
+
   // If the user didn't request waiting, print the immediate response.
   if (!nonBlocking || !wait) {
     if (result?.kind === "message") {
@@ -173,6 +199,7 @@ async function main() {
       return;
     }
     if (result?.kind === "task") {
+      printTaskHandle(result);
       const text = extractFirstTextParts(result.status?.message?.parts);
       console.log(text || JSON.stringify(result, null, 2));
       return;
@@ -182,18 +209,22 @@ async function main() {
   }
 
   // Async task mode: wait for terminal task state via tasks/get.
-  const taskId = result?.kind === "task" ? result.id : result?.taskId;
-  if (!taskId || typeof taskId !== "string") {
+  const responseTaskId = result?.kind === "task" ? result.id : result?.taskId;
+  if (!responseTaskId || typeof responseTaskId !== "string") {
     // Can't wait if we don't know the task id.
     console.log(JSON.stringify(result, null, 2));
     return;
+  }
+
+  if (result?.kind === "task") {
+    printTaskHandle(result);
   }
 
   const startedAt = Date.now();
   const terminalStates = new Set(["completed", "failed", "canceled"]);
 
   while (true) {
-    const task = await client.getTask({ id: taskId, historyLength: 20 }, requestOptions);
+    const task = await client.getTask({ id: responseTaskId, historyLength: 20 }, requestOptions);
     const state = task?.status?.state;
 
     if (state && terminalStates.has(state)) {
@@ -203,7 +234,7 @@ async function main() {
     }
 
     if (Date.now() - startedAt > timeoutMs) {
-      console.error(`Timeout waiting for task ${taskId} after ${timeoutMs}ms`);
+      console.error(`Timeout waiting for task ${responseTaskId} after ${timeoutMs}ms`);
       console.log(JSON.stringify(task, null, 2));
       process.exit(3);
     }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -12,6 +12,13 @@ const HOOKS_WAKE_TIMEOUT_MS = 5_000;
 const TASK_CONTEXT_CACHE_LIMIT = 10_000;
 
 /**
+ * Maximum number of messages retained in task history.
+ * Prevents unbounded growth in long-running conversations.
+ * The SDK's tasks/get historyLength param can further trim on read.
+ */
+const MAX_HISTORY_MESSAGES = 200;
+
+/**
  * Structured response from OpenClaw Gateway agent dispatch.
  * Carries both text and optional media URLs extracted from agent payloads.
  */
@@ -703,6 +710,19 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     const contextId = requestContext.contextId;
     this.rememberTaskContext(taskId, contextId);
 
+    // Carry forward conversation history from previous rounds (if any).
+    // The SDK's ResultManager replaces currentTask with { ...taskEvent }, so
+    // omitting history would wipe out prior messages.
+    //
+    // IMPORTANT: The SDK's _createRequestContext already appends the current
+    // user message to task.history before calling execute(). The ResultManager
+    // then checks messageId to avoid double-adding. We rely on this dedup —
+    // do NOT manually strip the current message from existingHistory.
+    const rawHistory = requestContext.task?.history ?? [];
+    const existingHistory = rawHistory.length > MAX_HISTORY_MESSAGES
+      ? rawHistory.slice(-MAX_HISTORY_MESSAGES)
+      : rawHistory;
+
     // Publish initial "working" state so the task is trackable during async dispatch
     const workingTask: Task = {
       kind: "task",
@@ -712,6 +732,7 @@ export class OpenClawAgentExecutor implements AgentExecutor {
         state: "working",
         timestamp: new Date().toISOString(),
       },
+      history: existingHistory,
     };
     eventBus.publish(workingTask);
 
@@ -742,6 +763,7 @@ export class OpenClawAgentExecutor implements AgentExecutor {
           message: failedMessage,
           timestamp: new Date().toISOString(),
         },
+        history: existingHistory,
       };
 
       eventBus.publish(failedTask);
@@ -769,6 +791,7 @@ export class OpenClawAgentExecutor implements AgentExecutor {
         message: responseMessage,
         timestamp: new Date().toISOString(),
       },
+      history: existingHistory,
       artifacts: [
         {
           artifactId: uuidv4(),
@@ -781,6 +804,10 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     eventBus.finished();
   }
 
+  // cancelTask intentionally omits history: it only receives taskId (no
+  // RequestContext), so loading history would require a TaskStore reference
+  // that the executor doesn't hold. Cancellation is a terminal state where
+  // consumers care about status, not conversation history.
   async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
     const contextId = this.taskContextByTaskId.get(taskId);
     if (!contextId) {

--- a/tests/multi-round.test.ts
+++ b/tests/multi-round.test.ts
@@ -1,0 +1,456 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import type { Task } from "@a2a-js/sdk";
+
+import { OpenClawAgentExecutor } from "../src/executor.js";
+import { FileTaskStore } from "../src/task-store.js";
+import type { GatewayConfig } from "../src/types.js";
+
+function makeConfig(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agentCard: {
+      name: "Test Agent",
+      description: "test card",
+      url: "http://127.0.0.1:18800/a2a/jsonrpc",
+      skills: [{ name: "chat" }],
+    },
+    server: {
+      host: "127.0.0.1",
+      port: 18800,
+    },
+    peers: [],
+    security: {
+      inboundAuth: "none",
+    },
+    routing: {
+      defaultAgentId: "default-agent",
+    },
+    ...overrides,
+  };
+}
+
+function createMockWebSocketClass(options?: {
+  onAgent?: (params: Record<string, unknown>) => void;
+  agentResponseText?: string;
+  agentResponsePayloads?: Array<Record<string, unknown>>;
+}) {
+  const agentResponseText = options?.agentResponseText ?? "Gateway response";
+  const agentResponsePayloads = options?.agentResponsePayloads;
+
+  return class MockGatewaySocket {
+    readyState = 0;
+    private readonly listeners = new Map<string, Set<(event: any) => void>>();
+
+    constructor(_url: string) {
+      this.listeners.set("open", new Set());
+      this.listeners.set("message", new Set());
+      this.listeners.set("error", new Set());
+      this.listeners.set("close", new Set());
+      queueMicrotask(() => {
+        this.readyState = 1;
+        this.emit("open", {});
+        queueMicrotask(() => {
+          this.emit("message", {
+            data: JSON.stringify({
+              type: "event",
+              event: "connect.challenge",
+              payload: { nonce: "test-nonce-123" },
+            }),
+          });
+        });
+      });
+    }
+
+    send(data: string): void {
+      const frame = JSON.parse(data) as { id: string; method: string; params?: any };
+      if (frame.method === "connect") {
+        this.respond(frame.id, true, { status: "ok" });
+        return;
+      }
+      if (frame.method === "sessions.resolve") {
+        this.respond(frame.id, true, { key: "session-1" });
+        return;
+      }
+      if (frame.method === "agent") {
+        options?.onAgent?.(frame.params || {});
+        this.respond(frame.id, true, { status: "accepted" });
+        const payloads = agentResponsePayloads ?? [{ kind: "text", text: agentResponseText }];
+        this.respond(frame.id, true, {
+          status: "ok",
+          result: { payloads },
+        });
+        return;
+      }
+      this.respond(frame.id, false, null, { message: `unsupported method ${frame.method}` });
+    }
+
+    close(): void {
+      this.readyState = 3;
+      this.emit("close", {});
+    }
+
+    addEventListener(type: string, listener: (event: any) => void): void {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type)?.add(listener);
+    }
+
+    removeEventListener(type: string, listener: (event: any) => void): void {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    private respond(id: string, ok: boolean, payload?: unknown, error?: unknown): void {
+      queueMicrotask(() => {
+        this.emit("message", {
+          data: JSON.stringify({
+            type: "res",
+            id,
+            ok,
+            payload,
+            error,
+          }),
+        });
+      });
+    }
+
+    private emit(type: string, event: unknown): void {
+      for (const listener of this.listeners.get(type) || []) {
+        listener(event);
+      }
+    }
+  };
+}
+
+function createApi() {
+  return {
+    config: { gateway: { port: 18789 } },
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+  } as any;
+}
+
+function createEventBus() {
+  const events: unknown[] = [];
+  let finishedCalled = false;
+
+  return {
+    events,
+    isFinished: () => finishedCalled,
+    bus: {
+      publish(event: unknown) {
+        events.push(event);
+      },
+      finished() {
+        finishedCalled = true;
+      },
+    } as any,
+  };
+}
+
+async function executeRound(executor: OpenClawAgentExecutor, taskId: string, contextId: string): Promise<void> {
+  const eventBus = createEventBus();
+
+  await executor.execute(
+    {
+      taskId,
+      contextId,
+      userMessage: {
+        kind: "message",
+        messageId: `msg-${taskId}`,
+        role: "user",
+        agentId: "writer-agent",
+        parts: [{ kind: "text", text: `hello-${taskId}` }],
+      },
+    } as any,
+    eventBus.bus,
+  );
+
+  assert.equal(eventBus.isFinished(), true);
+  assert.equal((eventBus.events.at(-1) as Task).status.state, "completed");
+}
+
+describe("multi-round conversation routing", () => {
+  it("reuses the same sessionKey for two rounds with the same contextId", async () => {
+    const sessionKeys: string[] = [];
+    const MockWS = createMockWebSocketClass({
+      onAgent: (params) => {
+        if (typeof params.sessionKey === "string") {
+          sessionKeys.push(params.sessionKey);
+        }
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+
+      await executeRound(executor, "task-round-1", "ctx-round");
+      await executeRound(executor, "task-round-2", "ctx-round");
+
+      assert.deepEqual(sessionKeys, [
+        "agent:writer-agent:a2a:ctx-round",
+        "agent:writer-agent:a2a:ctx-round",
+      ]);
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("uses different sessionKeys for different contextIds", async () => {
+    const sessionKeys: string[] = [];
+    const MockWS = createMockWebSocketClass({
+      onAgent: (params) => {
+        if (typeof params.sessionKey === "string") {
+          sessionKeys.push(params.sessionKey);
+        }
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+
+      await executeRound(executor, "task-ctx-a", "ctx-a");
+      await executeRound(executor, "task-ctx-b", "ctx-b");
+
+      assert.equal(sessionKeys.length, 2);
+      assert.notEqual(sessionKeys[0], sessionKeys[1]);
+      assert.equal(sessionKeys[0], "agent:writer-agent:a2a:ctx-a");
+      assert.equal(sessionKeys[1], "agent:writer-agent:a2a:ctx-b");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("keeps taskContextByTaskId mapped for multiple taskIds in the same context", async () => {
+    const MockWS = createMockWebSocketClass();
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+
+      await executeRound(executor, "task-map-1", "ctx-shared");
+      await executeRound(executor, "task-map-2", "ctx-shared");
+
+      const taskContextByTaskId = (executor as any).taskContextByTaskId as Map<string, string>;
+      assert.equal(taskContextByTaskId.get("task-map-1"), "ctx-shared");
+      assert.equal(taskContextByTaskId.get("task-map-2"), "ctx-shared");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+});
+
+describe("history preservation across rounds", () => {
+  it("completed task carries forward existing history from requestContext.task", async () => {
+    const MockWS = createMockWebSocketClass({
+      agentResponseText: "round-2 response",
+    });
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+      const eventBus = createEventBus();
+
+      // Simulate a second-round request where the SDK passes the task
+      // with history from the first round.
+      const previousHistory = [
+        {
+          kind: "message" as const,
+          messageId: "msg-round-1-user",
+          role: "user" as const,
+          contextId: "ctx-hist",
+          parts: [{ kind: "text" as const, text: "round-1 question" }],
+        },
+        {
+          kind: "message" as const,
+          messageId: "msg-round-1-agent",
+          role: "agent" as const,
+          contextId: "ctx-hist",
+          parts: [{ kind: "text" as const, text: "round-1 answer" }],
+        },
+      ];
+
+      await executor.execute(
+        {
+          taskId: "task-hist-2",
+          contextId: "ctx-hist",
+          task: {
+            kind: "task",
+            id: "task-hist-2",
+            contextId: "ctx-hist",
+            status: { state: "working", timestamp: new Date().toISOString() },
+            history: previousHistory,
+          },
+          userMessage: {
+            kind: "message",
+            messageId: "msg-round-2-user",
+            role: "user",
+            parts: [{ kind: "text", text: "round-2 question" }],
+          },
+        } as any,
+        eventBus.bus,
+      );
+
+      assert.equal(eventBus.isFinished(), true);
+
+      // The completed task must carry the previous history
+      const completedTask = eventBus.events.at(-1) as Task;
+      assert.equal(completedTask.status.state, "completed");
+      assert.ok(completedTask.history, "completed task should have history");
+      assert.equal(completedTask.history!.length, 2, "should carry 2 previous messages");
+      assert.equal((completedTask.history![0] as any).messageId, "msg-round-1-user");
+      assert.equal((completedTask.history![1] as any).messageId, "msg-round-1-agent");
+
+      // The working event should also carry history
+      const workingTask = eventBus.events[0] as Task;
+      assert.ok(workingTask.history, "working task should have history");
+      assert.equal(workingTask.history!.length, 2);
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("truncates history exceeding MAX_HISTORY_MESSAGES (200)", async () => {
+    const MockWS = createMockWebSocketClass();
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+      const eventBus = createEventBus();
+
+      // Build a history with 250 messages (exceeds the 200 cap)
+      const bigHistory = Array.from({ length: 250 }, (_, i) => ({
+        kind: "message" as const,
+        messageId: `msg-${i}`,
+        role: (i % 2 === 0 ? "user" : "agent") as "user" | "agent",
+        contextId: "ctx-big",
+        parts: [{ kind: "text" as const, text: `message ${i}` }],
+      }));
+
+      await executor.execute(
+        {
+          taskId: "task-big",
+          contextId: "ctx-big",
+          task: {
+            kind: "task",
+            id: "task-big",
+            contextId: "ctx-big",
+            status: { state: "working", timestamp: new Date().toISOString() },
+            history: bigHistory,
+          },
+          userMessage: {
+            kind: "message",
+            messageId: "msg-big-next",
+            role: "user",
+            parts: [{ kind: "text", text: "next" }],
+          },
+        } as any,
+        eventBus.bus,
+      );
+
+      const completedTask = eventBus.events.at(-1) as Task;
+      assert.equal(completedTask.status.state, "completed");
+      assert.ok(completedTask.history, "should have history");
+      assert.equal(completedTask.history!.length, 200, "should cap at 200 messages");
+      // Should keep the LATEST 200 (indices 50-249)
+      assert.equal((completedTask.history![0] as any).messageId, "msg-50");
+      assert.equal((completedTask.history![199] as any).messageId, "msg-249");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("first round (no prior task) has empty history", async () => {
+    const MockWS = createMockWebSocketClass();
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(createApi(), makeConfig() as GatewayConfig);
+      const eventBus = createEventBus();
+
+      await executor.execute(
+        {
+          taskId: "task-first",
+          contextId: "ctx-first",
+          userMessage: {
+            kind: "message",
+            messageId: "msg-first",
+            role: "user",
+            parts: [{ kind: "text", text: "hello" }],
+          },
+        } as any,
+        eventBus.bus,
+      );
+
+      const completedTask = eventBus.events.at(-1) as Task;
+      assert.equal(completedTask.status.state, "completed");
+      assert.ok(Array.isArray(completedTask.history), "history should be an array");
+      assert.equal(completedTask.history!.length, 0, "first round should have empty history");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+});
+
+describe("FileTaskStore multi-round persistence", () => {
+  it("keeps the latest saved task state after multiple saves", async () => {
+    const tasksDir = await mkdtemp(path.join(os.tmpdir(), "a2a-gateway-multi-round-"));
+
+    try {
+      const store = new FileTaskStore(tasksDir);
+
+      await store.save({
+        kind: "task",
+        id: "task-1",
+        contextId: "ctx-round",
+        status: {
+          state: "working",
+          timestamp: new Date().toISOString(),
+        },
+      } as Task);
+
+      await store.save({
+        kind: "task",
+        id: "task-1",
+        contextId: "ctx-round",
+        status: {
+          state: "completed",
+          timestamp: new Date().toISOString(),
+          message: {
+            kind: "message",
+            messageId: "msg-task-1-completed",
+            role: "agent",
+            contextId: "ctx-round",
+            parts: [{ kind: "text", text: "latest-completed-message" }],
+          },
+        },
+      } as Task);
+
+      const restored = await store.load("task-1");
+
+      assert.ok(restored, "task should load after repeated saves");
+      assert.equal(restored.status.state, "completed");
+      assert.equal(restored.status.message?.parts?.[0]?.kind, "text");
+      assert.equal(restored.status.message?.parts?.[0]?.text, "latest-completed-message");
+    } finally {
+      await rm(tasksDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Executor history preservation**: Carries forward `requestContext.task.history` across rounds, preventing SDK ResultManager from wiping prior messages. Capped at 200 messages to prevent unbounded growth.
- **CLI continuation params**: `a2a-send.mjs` adds `--task-id`, `--context-id` for follow-up turns. Prints `[task] id=... contextId=...` for easy continuation. Input truncated to 256 chars.
- **7 new tests**: sessionKey reuse, context isolation, history carry-forward, history cap at 200, first-round empty history, taskContext mapping, FileTaskStore multi-save.

## Key design decisions

1. Multi-round uses same `contextId` (routes to same OpenClaw session) but creates new tasks each round (A2A spec: completed tasks are immutable)
2. History cap at 200 messages — SDK's `tasks/get historyLength` can further trim on read
3. `--task-id` only useful for in-progress tasks; for follow-up after completion, use `--context-id` only

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — 27/27 pass (20 existing + 7 new)
- [x] Live 2-round conversation via `a2a-send.mjs` — same sessionKey confirmed in logs
- [x] Task persistence verified (`/app/data/tasks/`)
- [x] Metrics endpoint correct (`started=2, completed=2, failed=0`)
- [x] Discord regression — AntiBot responds normally in #test
- [x] `--help` output includes new params

🤖 Generated with [Claude Code](https://claude.com/claude-code)