### PR TITLE
feat: task TTL cleanup with configurable expiration (P3)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,7 @@ import { buildAgentCard } from "./src/agent-card.js";
 import { A2AClient } from "./src/client.js";
 import { OpenClawAgentExecutor } from "./src/executor.js";
 import { QueueingAgentExecutor } from "./src/queueing-executor.js";
+import { runTaskCleanup } from "./src/task-cleanup.js";
 import { FileTaskStore } from "./src/task-store.js";
 import { GatewayTelemetry } from "./src/telemetry.js";
 import type {
@@ -167,6 +168,8 @@ function parseConfig(raw: unknown, resolvePath?: (nextPath: string) => string): 
     },
     storage: {
       tasksDir: resolveConfiguredPath(storage.tasksDir, "data/tasks", resolvePath),
+      taskTtlHours: Math.max(1, asNumber(storage.taskTtlHours, 72)),
+      cleanupIntervalMinutes: Math.max(1, asNumber(storage.cleanupIntervalMinutes, 60)),
     },
     peers: parsePeers(config.peers),
     security: {
@@ -307,6 +310,7 @@ const plugin = {
 
     let server: Server | null = null;
     let grpcServer: GrpcServer | null = null;
+    let cleanupTimer: ReturnType<typeof setInterval> | null = null;
     const grpcPort = config.server.port + 1;
 
     api.registerGatewayMethod("a2a.metrics", ({ respond }) => {
@@ -526,8 +530,30 @@ const plugin = {
           api.logger.warn(`a2a-gateway: gRPC init failed: ${msg}`);
           grpcServer = null;
         }
+
+        // Start task TTL cleanup
+        const ttlMs = config.storage.taskTtlHours * 3_600_000;
+        const intervalMs = config.storage.cleanupIntervalMinutes * 60_000;
+
+        const doCleanup = () => {
+          void runTaskCleanup(taskStore, ttlMs, telemetry, api.logger);
+        };
+
+        // Run once at startup to clear any backlog
+        doCleanup();
+        cleanupTimer = setInterval(doCleanup, intervalMs);
+
+        api.logger.info(
+          `a2a-gateway: task cleanup enabled — ttl=${config.storage.taskTtlHours}h interval=${config.storage.cleanupIntervalMinutes}min`,
+        );
       },
       async stop(_ctx) {
+        // Stop task cleanup timer
+        if (cleanupTimer) {
+          clearInterval(cleanupTimer);
+          cleanupTimer = null;
+        }
+
         // Stop gRPC server
         if (grpcServer) {
           grpcServer.forceShutdown();

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -52,7 +52,19 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "tasksDir": { "type": "string", "default": "data/tasks" }
+          "tasksDir": { "type": "string", "default": "data/tasks" },
+          "taskTtlHours": {
+            "type": "number",
+            "default": 72,
+            "minimum": 1,
+            "description": "Hours before completed/failed/canceled tasks are automatically deleted (default 72h)"
+          },
+          "cleanupIntervalMinutes": {
+            "type": "number",
+            "default": 60,
+            "minimum": 1,
+            "description": "Minutes between automatic task cleanup runs (default 60min)"
+          }
         }
       },
       "peers": {

--- a/src/task-cleanup.ts
+++ b/src/task-cleanup.ts
@@ -1,0 +1,88 @@
+import type { FileTaskStore } from "./task-store.js";
+import type { GatewayTelemetry } from "./telemetry.js";
+
+type LoggerLike = { info: (msg: string) => void; warn: (msg: string) => void };
+
+/** Terminal states that are safe to expire. */
+const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
+
+export interface CleanupResult {
+  expired: number;
+  skipped: number;
+  errors: number;
+}
+
+/**
+ * Scan the task store and delete tasks that:
+ * 1. Are in a terminal state (completed/failed/canceled/rejected)
+ * 2. Have a `status.timestamp` older than `ttlMs`
+ *
+ * Active tasks and tasks without a timestamp are always skipped.
+ */
+export async function runTaskCleanup(
+  store: FileTaskStore,
+  ttlMs: number,
+  telemetry: GatewayTelemetry,
+  logger: LoggerLike,
+): Promise<CleanupResult> {
+  const result: CleanupResult = { expired: 0, skipped: 0, errors: 0 };
+  const now = Date.now();
+
+  let taskIds: string[];
+  try {
+    taskIds = await store.listAll();
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`a2a-gateway: task cleanup failed to list tasks: ${msg}`);
+    return result;
+  }
+
+  if (taskIds.length === 0) {
+    return result;
+  }
+
+  for (const taskId of taskIds) {
+    try {
+      const task = await store.load(taskId);
+      if (!task) {
+        // File disappeared between listAll and load — not an error
+        continue;
+      }
+
+      const { state } = task.status;
+      if (!TERMINAL_STATES.has(state)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const timestamp = task.status.timestamp;
+      if (!timestamp) {
+        // No timestamp → can't determine age → skip
+        result.skipped += 1;
+        continue;
+      }
+
+      const age = now - new Date(timestamp).getTime();
+      if (isNaN(age) || age < ttlMs) {
+        result.skipped += 1;
+        continue;
+      }
+
+      await store.delete(taskId);
+      telemetry.recordTaskExpired(taskId, state);
+      result.expired += 1;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.warn(`a2a-gateway: task cleanup error for ${taskId}: ${msg}`);
+      result.errors += 1;
+    }
+  }
+
+  if (result.expired > 0) {
+    logger.info(
+      `a2a-gateway: task cleanup completed — expired=${result.expired} skipped=${result.skipped} errors=${result.errors}`,
+    );
+  }
+
+  return result;
+}

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type { Task } from "@a2a-js/sdk";
@@ -14,6 +14,7 @@ function taskFileName(taskId: string): string {
 
 export class FileTaskStore implements TaskStore {
   private readonly tasksDir: string;
+  private dirReady: Promise<void> | null = null;
 
   constructor(tasksDir: string) {
     this.tasksDir = path.resolve(tasksDir);
@@ -33,7 +34,7 @@ export class FileTaskStore implements TaskStore {
   }
 
   async save(task: Task, _context?: ServerCallContext): Promise<void> {
-    await mkdir(this.tasksDir, { recursive: true });
+    await this.ensureDir();
 
     const nextTask = cloneTask(task);
     const targetPath = this.taskPath(task.id);
@@ -44,7 +45,43 @@ export class FileTaskStore implements TaskStore {
     await rename(tmpPath, targetPath);
   }
 
+  /** List all stored task IDs. */
+  async listAll(): Promise<string[]> {
+    try {
+      const entries = await readdir(this.tasksDir);
+      return entries
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => decodeURIComponent(name.slice(0, -5)));
+    } catch (error: unknown) {
+      const code = (error as { code?: string } | undefined)?.code;
+      if (code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  /** Delete a task file. Silently ignores missing files. */
+  async delete(taskId: string): Promise<void> {
+    try {
+      await unlink(this.taskPath(taskId));
+    } catch (error: unknown) {
+      const code = (error as { code?: string } | undefined)?.code;
+      if (code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+  }
+
   private taskPath(taskId: string): string {
     return path.join(this.tasksDir, taskFileName(taskId));
+  }
+
+  private ensureDir(): Promise<void> {
+    if (!this.dirReady) {
+      this.dirReady = mkdir(this.tasksDir, { recursive: true }).then(() => {});
+    }
+    return this.dirReady;
   }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -30,8 +30,10 @@ interface TaskMetrics {
   max_queue_depth_observed: number;
   total_duration_ms: number;
   finished: number;
+  expired: number;
   last_started_at?: string;
   last_finished_at?: string;
+  last_cleanup_at?: string;
 }
 
 export interface GatewayTelemetrySnapshot {
@@ -71,6 +73,7 @@ export class GatewayTelemetry {
     max_queue_depth_observed: 0,
     total_duration_ms: 0,
     finished: 0,
+    expired: 0,
   };
 
   constructor(logger: LoggerLike, options: GatewayTelemetryOptions = {}) {
@@ -194,6 +197,15 @@ export class GatewayTelemetry {
       task_id: taskId,
       context_id: contextId,
       queue_depth: queueDepth,
+    });
+  }
+
+  recordTaskExpired(taskId: string, state: string): void {
+    this.tasks.expired += 1;
+    this.tasks.last_cleanup_at = new Date().toISOString();
+    this.log("info", "task.expired", {
+      task_id: taskId,
+      state,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,8 @@ export interface GatewayConfig {
   };
   storage: {
     tasksDir: string;
+    taskTtlHours: number;
+    cleanupIntervalMinutes: number;
   };
   peers: PeerConfig[];
   security: SecurityConfig;

--- a/tests/task-ttl.test.ts
+++ b/tests/task-ttl.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import type { Task } from "@a2a-js/sdk";
+
+import { runTaskCleanup } from "../src/task-cleanup.js";
+import { FileTaskStore } from "../src/task-store.js";
+import { GatewayTelemetry } from "../src/telemetry.js";
+
+function silentLogger() {
+  return {
+    info() {},
+    warn() {},
+    error() {},
+  } as any;
+}
+
+function makeTelemetry() {
+  return new GatewayTelemetry(silentLogger(), { structuredLogs: false });
+}
+
+function makeTask(
+  taskId: string,
+  state: string,
+  timestamp?: string,
+): Task {
+  return {
+    kind: "task",
+    id: taskId,
+    contextId: `ctx-${taskId}`,
+    status: {
+      state: state as any,
+      ...(timestamp !== undefined ? { timestamp } : {}),
+    },
+  };
+}
+
+function hoursAgo(hours: number): string {
+  return new Date(Date.now() - hours * 3_600_000).toISOString();
+}
+
+describe("FileTaskStore extensions", () => {
+  it("listAll returns all stored task IDs", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-list-"));
+    try {
+      const store = new FileTaskStore(dir);
+      await store.save(makeTask("alpha-uno", "completed", hoursAgo(1)));
+      await store.save(makeTask("beta-dos", "failed", hoursAgo(2)));
+      await store.save(makeTask("gamma-tres", "working", hoursAgo(3)));
+
+      const ids = await store.listAll();
+      assert.equal(ids.length, 3);
+      assert.ok(ids.includes("alpha-uno"));
+      assert.ok(ids.includes("beta-dos"));
+      assert.ok(ids.includes("gamma-tres"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("listAll returns empty array when directory does not exist", async () => {
+    const store = new FileTaskStore("/tmp/a2a-ttl-nonexistent-dir-xyz");
+    const ids = await store.listAll();
+    assert.equal(ids.length, 0);
+  });
+
+  it("delete removes a task file", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-del-"));
+    try {
+      const store = new FileTaskStore(dir);
+      await store.save(makeTask("doomed-task", "completed", hoursAgo(1)));
+
+      const before = await store.load("doomed-task");
+      assert.ok(before, "task should exist before delete");
+
+      await store.delete("doomed-task");
+
+      const after = await store.load("doomed-task");
+      assert.equal(after, undefined, "task should be gone after delete");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("delete silently ignores non-existent task", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-delnx-"));
+    try {
+      const store = new FileTaskStore(dir);
+      // Should not throw
+      await store.delete("ghost-task-42");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("mkdir lazy init: directory created only once", async () => {
+    const dir = path.join(os.tmpdir(), `a2a-ttl-lazy-${Date.now()}`);
+    try {
+      const store = new FileTaskStore(dir);
+
+      // Directory should not exist yet
+      let exists = false;
+      try {
+        await readdir(dir);
+        exists = true;
+      } catch {
+        exists = false;
+      }
+      assert.equal(exists, false, "dir should not exist before first save");
+
+      // First save creates the directory
+      await store.save(makeTask("lazy-1", "completed", hoursAgo(1)));
+      const entries1 = await readdir(dir);
+      assert.equal(entries1.length, 1);
+
+      // Second save reuses the directory (no error)
+      await store.save(makeTask("lazy-2", "completed", hoursAgo(1)));
+      const entries2 = await readdir(dir);
+      assert.equal(entries2.length, 2);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Task TTL cleanup", () => {
+  it("expires terminal tasks older than TTL", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-expire-"));
+    try {
+      const store = new FileTaskStore(dir);
+      const telemetry = makeTelemetry();
+
+      // Old terminal tasks — should be expired
+      await store.save(makeTask("old-completed-999", "completed", hoursAgo(100)));
+      await store.save(makeTask("old-failed-888", "failed", hoursAgo(200)));
+      await store.save(makeTask("old-canceled-777", "canceled", hoursAgo(150)));
+      await store.save(makeTask("old-rejected-666", "rejected", hoursAgo(80)));
+
+      // Fresh terminal task — should survive
+      await store.save(makeTask("fresh-completed-111", "completed", hoursAgo(1)));
+
+      const ttl72h = 72 * 3_600_000;
+      const result = await runTaskCleanup(store, ttl72h, telemetry, silentLogger());
+
+      assert.equal(result.expired, 4, "4 old terminal tasks should be expired");
+      assert.equal(result.skipped, 1, "1 fresh task should be skipped");
+
+      // Verify expired tasks are gone
+      assert.equal(await store.load("old-completed-999"), undefined);
+      assert.equal(await store.load("old-failed-888"), undefined);
+      assert.equal(await store.load("old-canceled-777"), undefined);
+      assert.equal(await store.load("old-rejected-666"), undefined);
+
+      // Verify fresh task survives
+      const fresh = await store.load("fresh-completed-111");
+      assert.ok(fresh, "fresh task should survive");
+
+      // Verify telemetry
+      const snap = telemetry.snapshot();
+      assert.equal(snap.tasks.expired, 4);
+      assert.ok(snap.tasks.last_cleanup_at, "last_cleanup_at should be set");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips active tasks even if older than TTL", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-active-"));
+    try {
+      const store = new FileTaskStore(dir);
+      const telemetry = makeTelemetry();
+
+      // Old but active — must NOT be deleted
+      await store.save(makeTask("working-ancient-555", "working", hoursAgo(500)));
+      await store.save(makeTask("submitted-old-444", "submitted", hoursAgo(300)));
+      await store.save(makeTask("input-required-333", "input-required", hoursAgo(200)));
+
+      const ttl1h = 1 * 3_600_000;
+      const result = await runTaskCleanup(store, ttl1h, telemetry, silentLogger());
+
+      assert.equal(result.expired, 0, "no active tasks should be expired");
+      assert.equal(result.skipped, 3, "all active tasks should be skipped");
+
+      // Verify all still exist
+      assert.ok(await store.load("working-ancient-555"));
+      assert.ok(await store.load("submitted-old-444"));
+      assert.ok(await store.load("input-required-333"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips tasks without timestamp", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-nots-"));
+    try {
+      const store = new FileTaskStore(dir);
+      const telemetry = makeTelemetry();
+
+      // Terminal but no timestamp — should skip
+      await store.save(makeTask("no-timestamp-222", "completed"));
+
+      const ttl1h = 1 * 3_600_000;
+      const result = await runTaskCleanup(store, ttl1h, telemetry, silentLogger());
+
+      assert.equal(result.expired, 0);
+      assert.equal(result.skipped, 1);
+      assert.ok(await store.load("no-timestamp-222"), "task without timestamp should survive");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles empty task store gracefully", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-empty-"));
+    try {
+      const store = new FileTaskStore(dir);
+      const telemetry = makeTelemetry();
+
+      const result = await runTaskCleanup(store, 1, telemetry, silentLogger());
+
+      assert.equal(result.expired, 0);
+      assert.equal(result.skipped, 0);
+      assert.equal(result.errors, 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("handles non-existent task store directory", async () => {
+    const store = new FileTaskStore("/tmp/a2a-ttl-phantom-dir-xyz");
+    const telemetry = makeTelemetry();
+
+    const result = await runTaskCleanup(store, 1, telemetry, silentLogger());
+
+    assert.equal(result.expired, 0);
+    assert.equal(result.skipped, 0);
+    assert.equal(result.errors, 0);
+  });
+});


### PR DESCRIPTION
## Summary

FileTaskStore 的 task 文件永不删除，长期运行磁盘会爆。本 PR 添加自动清理机制：终态任务（completed/failed/canceled/rejected）超过 TTL 后自动删除。

## 一、FileTaskStore 增强

### 问题
- `save()` 每次都调 `mkdir`，浪费 syscall（P0 遗留技术债）
- 无法列出或删除 task 文件

### 改动
- `src/task-store.ts`：新增 `listAll()` 列出所有 taskId、`delete()` 删除 task 文件
- `src/task-store.ts`：mkdir 改为 lazy init（首次 save 时创建，后续复用 Promise）

### 回归测试
- `tests/task-ttl.test.ts`（5 个用例：listAll、delete、lazy init）

## 二、Task TTL Cleanup

### 问题
- Task 文件永不删除，长期运行磁盘膨胀

### 改动
- 新增 `src/task-cleanup.ts`：`runTaskCleanup()` 扫描 task store，删除过期终态任务
- `index.ts`：`start()` 时启动 cleanup 定时器（启动即清理 + 定时扫描），`stop()` 时清除
- `src/types.ts`：`storage` 新增 `taskTtlHours`（默认 72h）和 `cleanupIntervalMinutes`（默认 60min）
- `index.ts` `parseConfig()`：解析新字段，`Math.max(1, ...)` 下界保护
- `openclaw.plugin.json`：同步 configSchema（`additionalProperties: false` 合规）

### 安全策略
- **只删终态**：completed/failed/canceled/rejected
- **活跃态绝不删**：working/submitted/input-required，无论多久
- **无 timestamp 不删**：保守策略，跳过
- 单个 task 处理报错不影响其他

### 回归测试
- `tests/task-ttl.test.ts`（5 个用例：过期清理、活跃跳过、无时间戳跳过、空目录、不存在目录）

## 三、Telemetry 扩展

### 改动
- `src/telemetry.ts`：`TaskMetrics` 新增 `expired` 计数 + `last_cleanup_at` 时间戳
- 新增 `recordTaskExpired()` 方法，cleanup 时调用

## 与现有架构的协作关系

```
┌──────────────────────────────────────┐
│  index.ts (service start/stop)       │
│  ├─ setInterval → runTaskCleanup()   │  ← 本 PR 新增
│  └─ clearInterval on stop()          │
├──────────────────────────────────────┤
│  task-cleanup.ts 【本 PR 新增】       │
│  ├─ store.listAll()                  │
│  ├─ store.load() → check TTL        │
│  ├─ store.delete() → expired tasks   │
│  └─ telemetry.recordTaskExpired()    │
├──────────────────────────────────────┤
│  task-store.ts (增强，不改原有接口)    │
│  ├─ save() ← mkdir lazy init 优化   │
│  ├─ load() ← 不变                   │
│  ├─ listAll() 【新增】               │
│  └─ delete() 【新增】                │
├──────────────────────────────────────┤
│  telemetry.ts (扩展，不改原有接口)     │
│  └─ recordTaskExpired() 【新增】      │
├──────────────────────────────────────┤
│  executor.ts / queueing-executor.ts  │
│  └─ ❌ 不涉及，不修改                │
└──────────────────────────────────────┘
```

## 兼容性评估

### ✅ 完全兼容
| 项目 | 说明 |
|------|------|
| 不配置新字段 | 默认 72h TTL + 60min 间隔，行为安全 |
| 现有 task 文件 | 不满 72h 不会被删 |
| Metrics endpoint | 新增 `expired` 字段，不影响已有字段 |
| configSchema | 新字段有 default，不需要用户主动配置 |

### ❌ 不存在的不兼容
- 不改 A2A 协议行为
- 不改 Queue/Executor 逻辑
- 不改 Agent Card
- 不改认证流程

## 设计决策
- **只删终态**而非按时间一刀切——避免误删正在处理的长任务
- **无 timestamp 跳过**而非估算——保守优先，不猜
- **cleanup 独立模块**——不侵入 save/load 热路径，不影响性能
- **启动即清理**——处理重启前积压的过期任务

## Out of Scope
- 不加 REST API 手动触发清理
- 不清理 `.tmp` 残留文件（低优先级，未来考虑）
- 不加配置热更新

## 统计
```
7 files changed, 422 insertions(+), 3 deletions(-)
```

## 测试验证

### 自动化
- `tsc --noEmit` ✅
- `npm test` 99/99 PASS（含 10 个新 TTL 用例）

### Live（AntiBot 容器）
- 插件启动日志：`task cleanup enabled — ttl=72h interval=60min` ✅
- A2A 消息收发正常 ✅
- Metrics 含 `expired` 字段 ✅
- 未误删不满 TTL 的 task（19 个文件完好）✅
- Discord 回归正常 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)