### PR TITLE
fix: harden task cleanup retries

### DIFF
--- a/src/task-cleanup.ts
+++ b/src/task-cleanup.ts
@@ -5,6 +5,7 @@ type LoggerLike = { info: (msg: string) => void; warn: (msg: string) => void };
 
 /** Terminal states that are safe to expire. */
 const TERMINAL_STATES = new Set(["completed", "failed", "canceled", "rejected"]);
+const ACTIVE_CLEANUPS = new WeakSet<FileTaskStore>();
 
 export interface CleanupResult {
   expired: number;
@@ -25,64 +26,78 @@ export async function runTaskCleanup(
   telemetry: GatewayTelemetry,
   logger: LoggerLike,
 ): Promise<CleanupResult> {
+  if (ACTIVE_CLEANUPS.has(store)) {
+    return { expired: 0, skipped: 0, errors: 0 };
+  }
+
+  ACTIVE_CLEANUPS.add(store);
   const result: CleanupResult = { expired: 0, skipped: 0, errors: 0 };
   const now = Date.now();
 
-  let taskIds: string[];
   try {
-    taskIds = await store.listAll();
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.warn(`a2a-gateway: task cleanup failed to list tasks: ${msg}`);
-    return result;
-  }
-
-  if (taskIds.length === 0) {
-    return result;
-  }
-
-  for (const taskId of taskIds) {
+    let taskIds: string[];
     try {
-      const task = await store.load(taskId);
-      if (!task) {
-        // File disappeared between listAll and load — not an error
-        continue;
-      }
-
-      const { state } = task.status;
-      if (!TERMINAL_STATES.has(state)) {
-        result.skipped += 1;
-        continue;
-      }
-
-      const timestamp = task.status.timestamp;
-      if (!timestamp) {
-        // No timestamp → can't determine age → skip
-        result.skipped += 1;
-        continue;
-      }
-
-      const age = now - new Date(timestamp).getTime();
-      if (isNaN(age) || age < ttlMs) {
-        result.skipped += 1;
-        continue;
-      }
-
-      await store.delete(taskId);
-      telemetry.recordTaskExpired(taskId, state);
-      result.expired += 1;
+      taskIds = await store.listAll();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      logger.warn(`a2a-gateway: task cleanup error for ${taskId}: ${msg}`);
-      result.errors += 1;
+      logger.warn(`a2a-gateway: task cleanup failed to list tasks: ${msg}`);
+      return result;
     }
-  }
 
-  if (result.expired > 0) {
-    logger.info(
-      `a2a-gateway: task cleanup completed — expired=${result.expired} skipped=${result.skipped} errors=${result.errors}`,
-    );
-  }
+    if (taskIds.length === 0) {
+      return result;
+    }
 
-  return result;
+    for (const taskId of taskIds) {
+      try {
+        const task = await store.load(taskId);
+        if (!task) {
+          // File disappeared between listAll and load — not an error
+          continue;
+        }
+
+        const { state } = task.status;
+        if (!TERMINAL_STATES.has(state)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const timestamp = task.status.timestamp;
+        if (!timestamp) {
+          // No timestamp -> can't determine age -> skip
+          result.skipped += 1;
+          continue;
+        }
+
+        const age = now - new Date(timestamp).getTime();
+        if (isNaN(age) || age < ttlMs) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const deleted = await store.delete(taskId);
+        if (!deleted) {
+          result.skipped += 1;
+          continue;
+        }
+
+        telemetry.recordTaskExpired(taskId, state);
+        result.expired += 1;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.warn(`a2a-gateway: task cleanup error for ${taskId}: ${msg}`);
+        result.errors += 1;
+      }
+    }
+
+    if (result.expired > 0) {
+      logger.info(
+        `a2a-gateway: task cleanup completed - expired=${result.expired} skipped=${result.skipped} errors=${result.errors}`,
+      );
+    }
+
+    return result;
+  } finally {
+    ACTIVE_CLEANUPS.delete(store);
+  }
 }

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -61,14 +61,15 @@ export class FileTaskStore implements TaskStore {
     }
   }
 
-  /** Delete a task file. Silently ignores missing files. */
-  async delete(taskId: string): Promise<void> {
+  /** Delete a task file and report whether anything was removed. */
+  async delete(taskId: string): Promise<boolean> {
     try {
       await unlink(this.taskPath(taskId));
+      return true;
     } catch (error: unknown) {
       const code = (error as { code?: string } | undefined)?.code;
       if (code === "ENOENT") {
-        return;
+        return false;
       }
       throw error;
     }
@@ -80,7 +81,13 @@ export class FileTaskStore implements TaskStore {
 
   private ensureDir(): Promise<void> {
     if (!this.dirReady) {
-      this.dirReady = mkdir(this.tasksDir, { recursive: true }).then(() => {});
+      this.dirReady = mkdir(this.tasksDir, { recursive: true }).then(
+        () => {},
+        (error) => {
+          this.dirReady = null;
+          throw error;
+        },
+      );
     }
     return this.dirReady;
   }

--- a/tests/task-ttl.test.ts
+++ b/tests/task-ttl.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -76,9 +76,10 @@ describe("FileTaskStore extensions", () => {
       const before = await store.load("doomed-task");
       assert.ok(before, "task should exist before delete");
 
-      await store.delete("doomed-task");
+      const deleted = await store.delete("doomed-task");
 
       const after = await store.load("doomed-task");
+      assert.equal(deleted, true, "delete should report that it removed a task");
       assert.equal(after, undefined, "task should be gone after delete");
     } finally {
       await rm(dir, { recursive: true, force: true });
@@ -89,8 +90,8 @@ describe("FileTaskStore extensions", () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-delnx-"));
     try {
       const store = new FileTaskStore(dir);
-      // Should not throw
-      await store.delete("ghost-task-42");
+      const deleted = await store.delete("ghost-task-42");
+      assert.equal(deleted, false, "delete should report when nothing was removed");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -122,6 +123,29 @@ describe("FileTaskStore extensions", () => {
       assert.equal(entries2.length, 2);
     } finally {
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries directory creation after a transient mkdir failure", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-dirrecover-"));
+    const blocker = path.join(root, "blocked");
+    try {
+      await writeFile(blocker, "x", "utf8");
+      const store = new FileTaskStore(path.join(blocker, "tasks"));
+
+      await assert.rejects(
+        store.save(makeTask("first-attempt", "completed", hoursAgo(1))),
+        (error: unknown) => (error as { code?: string } | undefined)?.code === "ENOTDIR",
+      );
+
+      await rm(blocker, { force: true });
+      await mkdir(blocker, { recursive: true });
+
+      await store.save(makeTask("second-attempt", "completed", hoursAgo(1)));
+      const recovered = await store.load("second-attempt");
+      assert.ok(recovered, "save should recover once the directory path becomes valid");
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });
@@ -238,5 +262,26 @@ describe("Task TTL cleanup", () => {
     assert.equal(result.expired, 0);
     assert.equal(result.skipped, 0);
     assert.equal(result.errors, 0);
+  });
+
+  it("skips overlapping cleanup runs for the same store", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "a2a-ttl-overlap-"));
+    try {
+      const store = new FileTaskStore(dir);
+      const telemetry = makeTelemetry();
+
+      await store.save(makeTask("race-1", "completed", hoursAgo(100)));
+
+      const [first, second] = await Promise.all([
+        runTaskCleanup(store, 72 * 3_600_000, telemetry, silentLogger()),
+        runTaskCleanup(store, 72 * 3_600_000, telemetry, silentLogger()),
+      ]);
+
+      assert.equal(first.expired, 1);
+      assert.deepEqual(second, { expired: 0, skipped: 0, errors: 0 });
+      assert.equal(telemetry.snapshot().tasks.expired, 1, "telemetry should count the task only once");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Follow-up fix for #19.

This patch fixes two regressions introduced by task TTL cleanup:
- allow FileTaskStore directory initialization to recover after an initial mkdir failure
- prevent overlapping cleanup runs from double-counting the same expired task

Tests added:
- retry after transient mkdir failure
- overlapping cleanup runs only count expiration once

Validation:
- npm test
- npx tsc --noEmit