### PR TITLE
feat: SSE streaming with heartbeat keep-alive (P4)

### DIFF
--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -43,7 +43,7 @@ import { randomUUID } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { extname } from "node:path";
 
-const USAGE = `Usage: node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message <TEXT> [--file-uri <url>] [--file-path <localpath>] [--task-id <id>] [--context-id <id>] [--non-blocking] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>] [--help]`;
+const USAGE = `Usage: node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message <TEXT> [--file-uri <url>] [--file-path <localpath>] [--task-id <id>] [--context-id <id>] [--non-blocking] [--wait] [--stream] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>] [--help]`;
 
 const MAX_INLINE_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -145,6 +145,7 @@ async function main() {
 
   const nonBlocking = Boolean(opts["non-blocking"] || opts.nonBlocking);
   const wait = Boolean(opts.wait);
+  const stream = Boolean(opts.stream);
 
   const timeoutMsRaw = opts["timeout-ms"] || opts.timeoutMs;
   const pollMsRaw = opts["poll-ms"] || opts.pollMs;
@@ -254,6 +255,34 @@ async function main() {
     message: outboundMessage,
     ...(nonBlocking ? { configuration: { blocking: false } } : {}),
   };
+
+  // SSE streaming mode: subscribe to task event stream
+  if (stream) {
+    console.log("[stream] connecting...");
+    const eventStream = client.sendMessageStream(sendParams, requestOptions);
+    for await (const event of eventStream) {
+      const kind = event?.kind;
+      if (kind === "task") {
+        const state = event.status?.state;
+        const text = extractFirstTextParts(event.status?.message?.parts);
+        if (state === "working") {
+          console.log(`[stream] working... (${event.status?.timestamp || ""})`);
+        } else if (text) {
+          console.log(`[stream] ${state}: ${text}`);
+        } else {
+          console.log(`[stream] ${state}: ${JSON.stringify(event.status)}`);
+        }
+      } else if (kind === "status-update") {
+        const state = event.status?.state;
+        const text = extractFirstTextParts(event.status?.message?.parts);
+        console.log(`[stream] status-update: ${state}${text ? ` — ${text}` : ""}`);
+      } else {
+        console.log(`[stream] ${kind || "unknown"}: ${JSON.stringify(event)}`);
+      }
+    }
+    console.log("[stream] done");
+    return;
+  }
 
   const result = await client.sendMessage(sendParams, requestOptions);
 

--- a/src/agent-card.ts
+++ b/src/agent-card.ts
@@ -52,7 +52,7 @@ export function buildAgentCard(config: GatewayConfig): AgentCard {
     url: configuredUrl || fallbackUrl,
     skills: (agentCard.skills || []).map((entry, index) => toSkill(entry, index)),
     capabilities: {
-      streaming: false,
+      streaming: true,
       pushNotifications: false,
       stateTransitionHistory: false,
     },

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -19,6 +19,12 @@ const HOOKS_WAKE_TIMEOUT_MS = 5_000;
 const TASK_CONTEXT_CACHE_LIMIT = 10_000;
 
 /**
+ * Interval for SSE heartbeat events during agent dispatch.
+ * Keeps the SSE connection alive and signals clients the task is still working.
+ */
+const STREAMING_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
  * Maximum number of messages retained in task history.
  * Prevents unbounded growth in long-running conversations.
  * The SDK's tasks/get historyLength param can further trim on read.
@@ -774,9 +780,26 @@ export class OpenClawAgentExecutor implements AgentExecutor {
 
     let agentResponse: AgentResponse;
 
+    // Emit periodic heartbeat events while the agent is working.
+    // This keeps SSE connections alive and signals that the task is still in progress.
+    const heartbeat = setInterval(() => {
+      const heartbeatTask: Task = {
+        kind: "task",
+        id: taskId,
+        contextId,
+        status: {
+          state: "working",
+          timestamp: new Date().toISOString(),
+        },
+        history: existingHistory,
+      };
+      eventBus.publish(heartbeatTask);
+    }, STREAMING_HEARTBEAT_INTERVAL_MS);
+
     try {
       agentResponse = await this.dispatchViaGatewayRpc(agentId, requestContext.userMessage, contextId);
     } catch (err: unknown) {
+      clearInterval(heartbeat);
       const errorMessage = err instanceof Error ? err.message : String(err);
       const truncatedError = errorMessage.length > 500 ? errorMessage.slice(0, 500) + "..." : errorMessage;
       this.api.logger.error(`a2a-gateway: agent dispatch failed: ${truncatedError}`);
@@ -807,6 +830,8 @@ export class OpenClawAgentExecutor implements AgentExecutor {
       eventBus.finished();
       return;
     }
+
+    clearInterval(heartbeat);
 
     // Publish completed Task with artifact (text + optional file parts)
     const responseParts = buildResponseParts(agentResponse);

--- a/tests/a2a-gateway.test.ts
+++ b/tests/a2a-gateway.test.ts
@@ -319,7 +319,7 @@ describe("a2a-gateway plugin", () => {
     assert.ok(payload.security !== undefined, "security should be present");
 
     const capabilities = payload.capabilities as Record<string, unknown>;
-    assert.equal(capabilities.streaming, false);
+    assert.equal(capabilities.streaming, true);
     assert.equal(capabilities.pushNotifications, false);
     assert.equal(capabilities.stateTransitionHistory, false);
   });


### PR DESCRIPTION
## Summary

启用 A2A v0.3.0 SSE streaming transport。客户端可以通过 `message/stream` 实时订阅 task 状态事件，不再需要轮询。Executor 在 agent dispatch 期间每 15 秒发送 working 心跳，防止 SSE 连接被代理/防火墙断开。

## 一、Agent Card — 启用 streaming

### 改动
- `src/agent-card.ts`：`streaming: false` → `streaming: true`
- 这是 SDK 的门禁开关——为 false 时 `message/stream` 直接抛 `UnsupportedOperation`

### 回归测试
- `tests/a2a-gateway.test.ts`：更新 capability 断言（89/89 PASS）

## 二、Executor — 心跳 keep-alive

### 问题
- SSE 连接在长任务（agent 思考数十秒到数分钟）期间无数据，可能被代理/防火墙/客户端超时断开

### 改动
- `src/executor.ts`：在 `dispatchViaGatewayRpc` 等待期间，每 15 秒发一个 `Task { state: "working" }` 事件
- 成功/失败时立即 `clearInterval`，不泄漏 timer
- **不消耗 token**：心跳只是往 eventBus 发事件，不调 agent

## 三、客户端 --stream

### 改动
- `skill/scripts/a2a-send.mjs`：新增 `--stream` 参数
  - 使用 `client.sendMessageStream()` 订阅 SSE 事件流
  - 逐事件打印（working / completed / failed）
  - 不带 `--stream` 时行为完全不变

## 与现有架构的协作关系

```
┌─────────────────────────────────────────┐
│  SDK DefaultRequestHandler              │
│  ├─ sendMessage (不变)                   │
│  └─ sendMessageStream 【本PR启用】       │
│     ├─ fire executor.execute()           │
│     └─ for await (event of eventQueue)   │
├─────────────────────────────────────────┤
│  executor.ts                             │
│  ├─ publish(working)                     │
│  ├─ setInterval → publish(working) 心跳  │ ← 本PR新增
│  ├─ await dispatchViaGatewayRpc (不变)   │
│  ├─ clearInterval                        │ ← 本PR新增
│  └─ publish(completed) + finished()      │
├─────────────────────────────────────────┤
│  queueing-executor.ts                    │
│  └─ ❌ 不涉及（透传 eventBus）           │
├─────────────────────────────────────────┤
│  Express handlers (jsonRpc/REST)         │
│  └─ ❌ 不改（SDK 自动处理 SSE 输出）     │
└─────────────────────────────────────────┘
```

## 兼容性评估

### ✅ 完全兼容
| 项目 | 说明 |
|------|------|
| 普通 sendMessage | 不受影响，行为不变 |
| --non-blocking --wait | 不受影响，行为不变 |
| Agent Card | 仅 capabilities.streaming 从 false → true |
| 心跳事件 | 只在 SSE 连接存在时有意义，普通请求不触发 |

### ❌ 不存在的不兼容
- 不改 JSON-RPC/REST 路由
- 不改认证流程
- 不改 task store / telemetry
- 不改 gRPC transport（gRPC streaming 是独立的 future work）

## 设计决策
- **心跳用 Task 事件而非 TaskStatusUpdateEvent**：与现有 executor 的事件模式一致，SDK 的 ExecutionEventQueue 都能正确处理
- **15 秒间隔**：在 keep-alive 需求和日志噪音之间平衡。大多数代理 30-60 秒超时
- **协议层 streaming 先行**：Gateway RPC 目前只支持单次响应，token 级流式需要 Gateway 侧支持多次 respond()，不在本 PR 范围

## Out of Scope
- Token 级实时流式（需 Gateway RPC 改造）
- gRPC streaming
- 配置项控制 streaming 开关
- Telemetry streaming 计数（可后续加）

## 统计
```
4 files changed, 57 insertions(+), 3 deletions(-)
```

## 测试验证

### 自动化
- `tsc --noEmit` ✅
- `npm test` 89/89 PASS ✅

### Live（AntiBot 容器）
- Agent Card `streaming: true` ✅
- 普通模式回归正常 ✅
- `--stream` 模式：working → completed 事件流正确 ✅
- Discord 回归正常 ✅
- A2A 跨节点通路正常（AntiBot → AWS-bot）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)