### PR TITLE
fix: replace raw WS dispatch with Plugin SDK subagent.run()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7441,7 +7441,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1044,61 +1044,68 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     contextId: string,
   ): Promise<AgentResponse> {
     const messageText = extractInboundMessageText(userMessage);
-    const gatewayConfig = this.resolveGatewayRuntimeConfig();
-    const gateway = new GatewayRpcConnection(gatewayConfig);
 
-    await gateway.connect();
+    // Use the Plugin SDK's subagent.run() API instead of raw WebSocket RPC.
+    // The WS "agent" method requires operator.write scope which needs device
+    // identity — but the Plugin SDK's runtime already has full gateway access
+    // without needing to re-authenticate via WS.
+    const sessionKey = `agent:${agentId}:a2a:${contextId}`;
+    const runId = uuidv4();
 
     try {
-      // Derive a deterministic session key from A2A contextId for:
-      // 1. Session reuse across messages in the same A2A context (conversation continuity)
-      // 2. Isolation between different A2A contexts (no cross-contamination)
-      // The gateway `agent` RPC auto-creates the session if it doesn't exist.
-      const sessionKey = `agent:${agentId}:a2a:${contextId}`;
-
-      const runId = uuidv4();
-      const agentParams: Record<string, unknown> = {
-        agentId,
+      const result = await this.api.runtime.subagent.run({
+        sessionKey,
         message: messageText,
         deliver: false,
         idempotencyKey: runId,
+      });
+
+      // Wait for the agent run to complete
+      const waitResult = await this.api.runtime.subagent.waitForRun({
+        runId: result.runId,
+        timeoutMs: this.agentResponseTimeoutMs,
+      });
+
+      if (waitResult.status === "error") {
+        throw new Error(waitResult.error || "Agent run failed");
+      }
+      if (waitResult.status === "timeout") {
+        throw new Error("Agent run timed out");
+      }
+
+      // Retrieve the assistant's response from session history
+      const historyResult = await this.api.runtime.subagent.getSessionMessages({
         sessionKey,
-      };
+        limit: 50,
+      });
 
-      const finalPayload = await gateway.request(
-        "agent",
-        agentParams,
-        this.agentResponseTimeoutMs,
-        true,
-      );
-      const finalBody = asObject(finalPayload);
-      const status = asString(finalBody?.status);
-      if (status && status !== "ok") {
-        const summary = asString(finalBody?.summary) || "Agent run did not complete";
-        throw new Error(summary);
+      const messages = historyResult.messages as Array<Record<string, unknown>>;
+      // Find the latest assistant message
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i];
+        if (msg?.role === "assistant") {
+          const content = msg.content;
+          if (typeof content === "string") {
+            return { text: content, mediaUrls: [] };
+          }
+          if (Array.isArray(content)) {
+            const textParts = content
+              .filter((p: unknown) => {
+                const part = p as Record<string, unknown>;
+                return part?.type === "text" && typeof part?.text === "string";
+              })
+              .map((p: unknown) => (p as Record<string, string>).text);
+            if (textParts.length > 0) {
+              return { text: textParts.join("\n"), mediaUrls: [] };
+            }
+          }
+        }
       }
 
-      const agentResponse = extractAgentResponse(finalPayload);
-      if (agentResponse) {
-        return agentResponse;
-      }
-
-      // sessionKey is always available (deterministic from contextId),
-      // so we can always try to retrieve the latest assistant reply from history.
-      const historyPayload = await gateway.request(
-        "chat.history",
-        { sessionKey, limit: 50 },
-        GATEWAY_REQUEST_TIMEOUT_MS,
-        false,
-      );
-      const historyText = extractLatestAssistantReply(historyPayload);
-      if (historyText) {
-        return { text: historyText, mediaUrls: [] };
-      }
-
-      throw new Error("No assistant response text returned by gateway");
-    } finally {
-      gateway.close();
+      throw new Error("No assistant response text returned by agent");
+    } catch (err) {
+      // Re-throw to let the outer executeTask catch handle it
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Problem

Since OpenClaw 2026.3.x, the gateway clears all WebSocket scopes for connections without device identity. The A2A executor connects via `GatewayRpcConnection` (raw WebSocket) without providing device identity, so all scopes are stripped — including `operator.write`, which the `agent` method requires.

This causes **every** A2A inbound dispatch to fail with:
```
errorCode=INVALID_REQUEST errorMessage=missing scope: operator.write
```

### Root Cause

In the gateway WS handshake (`gateway-cli-Ol-vpIk7.js`), `handleMissingDeviceIdentity()` calls:
```js
if (!device && (!isControlUi || decision.kind !== "allow")) clearUnboundScopes();
```

For CLI-mode connections (which the executor uses), `!isControlUi` is `true`, so the OR short-circuits — scopes are **always** cleared regardless of whether token auth succeeded. The `evaluateMissingDeviceIdentity` function correctly returns `"allow"` (because `roleCanSkipDeviceIdentity(role="operator", sharedAuthOk=true)` is true), but scopes are already zeroed by that point.

## Fix

Replace the raw `GatewayRpcConnection` dispatch with `api.runtime.subagent.run()` from the OpenClaw Plugin SDK. The SDK runtime has direct internal gateway access and does not need to re-authenticate via WebSocket.

This is the intended plugin API for agent dispatch — the executor already has access to `this.api` (the `OpenClawPluginApi` instance) but was only using it for logging and config reads.

### Changes

- `dispatchViaGatewayRpc()` now uses `api.runtime.subagent.run()` + `waitForRun()` + `getSessionMessages()`
- Session key derivation (`agent:{agentId}:a2a:{contextId}`) is preserved for conversation continuity
- Response extraction reads from session history (latest assistant message)

### Testing

Tested on two production OpenClaw instances (v2026.3.13) with bidirectional A2A:
```
Proshka → Ocean: "Океан! Прошка тестирует A2A после фикса. Слышишь? 🦞🤝"
Ocean → Proshka: "Слышу громко и чётко! 🌊🤝🦞"
```

Previously both directions failed with `missing scope: operator.write`.