### PR TITLE
feat: extract file URLs from agent text into outbound FileParts

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,7 @@ The plugin supports all three A2A Part types for inbound messages. Since the Ope
 | `FilePart` (base64) | `[Attached: photo.png (image/png), inline 45KB]` | Inline file with size hint |
 | `DataPart` | `[Data (application/json): {"key":"value"}]` | Structured JSON data (truncated at 2KB) |
 
-For outbound responses, the plugin converts structured `mediaUrl`/`mediaUrls` fields from the agent payload into `FilePart` entries in the A2A response.
-
-> **Note:** Outbound FilePart generation relies on structured `mediaUrl`/`mediaUrls` fields in the agent payload. URLs embedded in plain text (e.g., markdown links) are not automatically extracted into FileParts.
+For outbound responses, the plugin converts structured `mediaUrl`/`mediaUrls` fields from the agent payload into `FilePart` entries in the A2A response. Additionally, file URLs embedded in the agent's text response (markdown links like `[report](https://…/report.pdf)` and bare URLs like `https://…/data.csv`) are automatically extracted into `FilePart` entries when they end with a recognized file extension.
 
 ### a2a_send_file Agent Tool
 
@@ -572,6 +570,7 @@ The agent will follow the skill's procedure automatically.
 - ✅ **P9** Cross-platform tasksDir default path `~/.openclaw/a2a-tasks` (direct commit)
 - ✅ **v1.0.1** Ed25519 device identity for OpenClaw ≥2026.3.13 scope compatibility (commit 84f440c)
 - ✅ Metrics endpoint optional bearer auth (`observability.metricsAuth: "bearer"`)
+- ✅ Extract file URLs from agent text responses (markdown links, bare URLs) into outbound FileParts — only recognized file extensions are promoted
 
 ### Next
 
@@ -580,7 +579,6 @@ The agent will follow the skill's procedure automatically.
 - Push notifications support (store + sender) for long-running tasks
 - Automatic transport fallback (JSON-RPC → REST/gRPC)
 - Cross-implementation compatibility test matrix (Google reference server, etc.)
-- Extract URLs from agent text responses (markdown links, bare URLs) into outbound FileParts
 
 ## License
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -275,8 +275,74 @@ function extractAgentResponse(payload: unknown): AgentResponse | undefined {
 }
 
 /**
+ * File extensions that indicate a URL points to a downloadable file rather
+ * than a regular web page. Only URLs ending with one of these extensions
+ * (case-insensitive) are promoted to FileParts.
+ */
+const FILE_EXTENSIONS = new Set([
+  ".pdf", ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg",
+  ".csv", ".json", ".xml", ".yaml", ".yml",
+  ".zip", ".gz", ".tar", ".rar", ".7z",
+  ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+  ".txt", ".md", ".rtf",
+  ".mp3", ".mp4", ".wav", ".ogg", ".flac", ".aac", ".webm", ".avi", ".mov",
+]);
+
+/**
+ * Extract file URLs from agent text content. Captures:
+ * 1. Markdown links: `[text](url)` → the url portion
+ * 2. Bare URLs: `https?://...` not already inside markdown link parentheses
+ *
+ * Only URLs that end with a recognized file extension are returned.
+ * Results are deduplicated and any URLs already present in `existingUrls`
+ * are excluded to avoid duplicate FileParts.
+ */
+export function extractUrlsFromText(text: string, existingUrls: string[] = []): string[] {
+  const existingSet = new Set(existingUrls);
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  // 1. Extract markdown link URLs: [text](url)
+  const mdLinkRe = /\[(?:[^\]]*)\]\((https?:\/\/[^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = mdLinkRe.exec(text)) !== null) {
+    const url = match[1];
+    if (!seen.has(url)) {
+      seen.add(url);
+    }
+  }
+
+  // 2. Extract bare URLs not inside markdown link parentheses.
+  // We replace markdown links first to avoid double-matching.
+  const textWithoutMdLinks = text.replace(/\[(?:[^\]]*)\]\(https?:\/\/[^)]+\)/g, "");
+  const bareUrlRe = /https?:\/\/[^\s<>"')\]]+/g;
+  while ((match = bareUrlRe.exec(textWithoutMdLinks)) !== null) {
+    const url = match[0];
+    if (!seen.has(url)) {
+      seen.add(url);
+    }
+  }
+
+  // Filter to file URLs only and exclude already-known media URLs
+  for (const url of seen) {
+    // Extract the path portion (before query string / fragment)
+    const pathPart = url.split("?")[0].split("#")[0];
+    const dotIdx = pathPart.lastIndexOf(".");
+    if (dotIdx === -1) continue;
+
+    const ext = pathPart.slice(dotIdx).toLowerCase();
+    if (FILE_EXTENSIONS.has(ext) && !existingSet.has(url)) {
+      result.push(url);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Build A2A Part array from an AgentResponse. Produces TextPart for text
- * content and FilePart entries for each media URL.
+ * content, FilePart entries for each media URL, and additional FileParts
+ * for file URLs discovered in the text content.
  */
 function buildResponseParts(response: AgentResponse): Part[] {
   const parts: Part[] = [];
@@ -290,6 +356,17 @@ function buildResponseParts(response: AgentResponse): Part[] {
       kind: "file",
       file: { uri: url },
     });
+  }
+
+  // Extract file URLs from text that are not already in mediaUrls
+  if (response.text) {
+    const textUrls = extractUrlsFromText(response.text, response.mediaUrls);
+    for (const url of textUrls) {
+      parts.push({
+        kind: "file",
+        file: { uri: url },
+      });
+    }
   }
 
   // Ensure at least one part exists (A2A requires non-empty parts array)

--- a/tests/url-extraction.test.ts
+++ b/tests/url-extraction.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for extractUrlsFromText() in src/executor.ts
+ *
+ * Covers: markdown link extraction, bare URL extraction, deduplication,
+ * mediaUrls exclusion, non-file URL filtering, and mixed content.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { extractUrlsFromText } from "../src/executor.js";
+
+// ---------------------------------------------------------------------------
+// Markdown link extraction
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – markdown links", () => {
+  it("extracts URL from a markdown link with file extension", () => {
+    const text = "Here is the [report](https://example.com/report.pdf).";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://example.com/report.pdf"]);
+  });
+
+  it("extracts multiple markdown links", () => {
+    const text =
+      "See [chart](https://example.com/chart.png) and [data](https://example.com/data.csv).";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, [
+      "https://example.com/chart.png",
+      "https://example.com/data.csv",
+    ]);
+  });
+
+  it("handles markdown link with query string", () => {
+    const text = "Download [file](https://cdn.example.com/doc.pdf?token=abc123).";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://cdn.example.com/doc.pdf?token=abc123"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bare URL extraction
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – bare URLs", () => {
+  it("extracts a bare URL with file extension", () => {
+    const text = "Check https://example.com/data.csv for details";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://example.com/data.csv"]);
+  });
+
+  it("extracts http:// bare URL", () => {
+    const text = "Available at http://files.example.com/archive.zip";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["http://files.example.com/archive.zip"]);
+  });
+
+  it("extracts bare URL with path segments", () => {
+    const text = "See https://storage.example.com/uploads/2026/03/image.jpg here.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://storage.example.com/uploads/2026/03/image.jpg"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – deduplication", () => {
+  it("returns each URL only once when it appears multiple times", () => {
+    const text =
+      "Download https://example.com/report.pdf and also https://example.com/report.pdf again.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://example.com/report.pdf"]);
+  });
+
+  it("deduplicates across markdown and bare occurrences", () => {
+    const text =
+      "See [report](https://example.com/report.pdf) or visit https://example.com/report.pdf directly.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, ["https://example.com/report.pdf"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No double-extraction (mediaUrls exclusion)
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – mediaUrls exclusion", () => {
+  it("excludes URLs already present in existingUrls", () => {
+    const text = "Here is the [report](https://example.com/report.pdf).";
+    const existing = ["https://example.com/report.pdf"];
+    const urls = extractUrlsFromText(text, existing);
+    assert.deepEqual(urls, []);
+  });
+
+  it("keeps URLs not in existingUrls while excluding those that are", () => {
+    const text =
+      "Files: [a](https://example.com/a.pdf) and [b](https://example.com/b.csv).";
+    const existing = ["https://example.com/a.pdf"];
+    const urls = extractUrlsFromText(text, existing);
+    assert.deepEqual(urls, ["https://example.com/b.csv"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-file URLs ignored
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – non-file URLs ignored", () => {
+  it("does NOT extract plain webpage URLs without file extension", () => {
+    const text = "Visit https://example.com/page for more info.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, []);
+  });
+
+  it("does NOT extract markdown links to web pages", () => {
+    const text = "See [docs](https://example.com/docs/getting-started) for details.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, []);
+  });
+
+  it("does NOT extract URLs ending with unrecognized extensions", () => {
+    const text = "Check https://example.com/page.html and https://example.com/app.exe";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed content
+// ---------------------------------------------------------------------------
+
+describe("extractUrlsFromText – mixed content", () => {
+  it("extracts file URLs from text with multiple markdown links and bare URLs", () => {
+    const text = [
+      "I generated the following outputs:",
+      "- [Analysis Report](https://cdn.example.com/analysis.pdf)",
+      "- Raw data: https://cdn.example.com/raw-data.csv",
+      "- Dashboard: https://app.example.com/dashboard",
+      "- Also check https://cdn.example.com/chart.png for the chart",
+      "- [Project Page](https://example.com/project)",
+    ].join("\n");
+
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, [
+      "https://cdn.example.com/analysis.pdf",
+      "https://cdn.example.com/raw-data.csv",
+      "https://cdn.example.com/chart.png",
+    ]);
+  });
+
+  it("handles mixed content with existingUrls filtering", () => {
+    const text =
+      "See [report](https://example.com/report.pdf) and https://example.com/data.xlsx";
+    const existing = ["https://example.com/report.pdf"];
+    const urls = extractUrlsFromText(text, existing);
+    assert.deepEqual(urls, ["https://example.com/data.xlsx"]);
+  });
+
+  it("returns empty array when text has no URLs", () => {
+    const text = "This is plain text with no URLs at all.";
+    const urls = extractUrlsFromText(text);
+    assert.deepEqual(urls, []);
+  });
+
+  it("returns empty array for empty string", () => {
+    const urls = extractUrlsFromText("");
+    assert.deepEqual(urls, []);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract markdown links (`[text](url)`) and bare URLs from agent text responses into outbound `FilePart` entries
- Only file-like URLs are extracted (30+ recognized extensions: `.pdf`, `.png`, `.csv`, `.json`, `.zip`, etc.)
- Deduplicates against existing `mediaUrls` to avoid double FileParts
- Closes roadmap item: "Extract URLs from agent text responses (markdown links, bare URLs) into outbound FileParts"

## Changes

- `src/executor.ts`: Add `extractUrlsFromText()` + integrate into `buildResponseParts()`
- `tests/url-extraction.test.ts`: 17 test cases covering markdown links, bare URLs, dedup, exclusion, non-file filtering, mixed content
- `README.md`: Move roadmap item to Completed

## Test plan

- [x] 17/17 new tests pass
- [x] 182/182 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)