### PR TITLE
feat: automatic transport fallback (JSON-RPC → REST → gRPC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,13 +572,13 @@ The agent will follow the skill's procedure automatically.
 - ✅ Metrics endpoint optional bearer auth (`observability.metricsAuth: "bearer"`)
 - ✅ Extract file URLs from agent text responses (markdown links, bare URLs) into outbound FileParts — only recognized file extensions are promoted
 - ✅ Cross-implementation compatibility test matrix ([docs/COMPATIBILITY.md](docs/COMPATIBILITY.md))
+- ✅ **P10** Automatic transport fallback: JSON-RPC → REST → gRPC with retryable-error classification
 
 ### Next
 
 - Rule-based routing: choose peer + target agentId based on message type/tags/skills
 - DNS-based dynamic agent discovery (mDNS/DNS-SD) instead of hardcoded peer URLs
 - Push notifications support (store + sender) for long-running tasks
-- Automatic transport fallback (JSON-RPC → REST/gRPC)
 
 ## License
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,11 @@ import type { MessageSendParams, Message } from "@a2a-js/sdk";
 import type { OutboundSendResult, PeerConfig, RetryConfig } from "./types.js";
 import type { PeerHealthManager } from "./peer-health.js";
 import { withRetry } from "./peer-retry.js";
+import {
+  orderTransports,
+  isRetryableTransportError,
+  type TransportEndpoint,
+} from "./transport-fallback.js";
 
 /**
  * Build an AuthenticationHandler for bearer or apiKey auth.
@@ -129,7 +134,7 @@ export class A2AClient {
       };
     }
 
-    const doSend = () => this.doSendMessage(peer, message);
+    const doSend = () => this.doSendMessage(peer, message, options?.log);
 
     let result: OutboundSendResult;
     if (retryConfig && retryConfig.maxRetries > 0) {
@@ -151,52 +156,191 @@ export class A2AClient {
   }
 
   /**
-   * Core send logic (no retry / circuit breaker wrapping).
+   * Core send logic with automatic transport fallback.
+   *
+   * 1. Resolve the Agent Card to discover available transports.
+   * 2. Build the ordered list of transports (JSON-RPC > REST > gRPC).
+   * 3. Try sending via the preferred transport; on transport-level errors
+   *    (connection, timeout, 5xx) fall back to the next available transport.
+   * 4. Auth errors (401/403) and A2A protocol errors are NOT retried on
+   *    a different transport — they would fail identically.
    */
   private async doSendMessage(
     peer: PeerConfig,
     message: Record<string, unknown>,
+    log?: (level: "info" | "warn", msg: string, details?: Record<string, unknown>) => void,
   ): Promise<OutboundSendResult> {
-    const { baseUrl } = parseAgentCardUrl(peer.agentCardUrl);
-    const { factory, path } = this.buildFactory(peer);
+    const { baseUrl, path } = parseAgentCardUrl(peer.agentCardUrl);
+    const { factory } = this.buildFactory(peer);
+
+    // ------------------------------------------------------------------
+    // 1. Build the outbound A2A message (shared across all transports)
+    // ------------------------------------------------------------------
+    const targetAgentId = typeof (message as any)?.agentId === "string" ? String((message as any).agentId) : "";
+
+    const outboundMessage: any = {
+      kind: "message",
+      messageId: (message.messageId as string) || uuidv4(),
+      role: (message.role as Message["role"]) || "user",
+      parts: (message.parts as Message["parts"]) || [
+        { kind: "text", text: String(message.text || message.message || "") },
+      ],
+    };
+
+    if (targetAgentId) {
+      outboundMessage.agentId = targetAgentId;
+    }
+
+    const sendParams: MessageSendParams = {
+      message: outboundMessage,
+    };
+
+    const serviceParameters: Record<string, string> = {};
+    if (peer.auth?.token) {
+      if (peer.auth.type === "bearer") {
+        serviceParameters.authorization = `Bearer ${peer.auth.token}`;
+      } else {
+        serviceParameters["x-api-key"] = peer.auth.token;
+      }
+    }
+
+    const requestOptions = {
+      serviceParameters: Object.keys(serviceParameters).length ? serviceParameters : undefined,
+    };
+
+    // ------------------------------------------------------------------
+    // 2. Resolve the Agent Card and build ordered transport list
+    // ------------------------------------------------------------------
+    let transports: TransportEndpoint[];
 
     try {
-      const client = await factory.createFromUrl(baseUrl, path);
+      // Use SDK's card resolver (which already handles auth)
+      const resolver = new DefaultAgentCardResolver({
+        fetchImpl: peer.auth?.token
+          ? createAuthenticatingFetchWithRetry(fetch, createAuthHandler(peer)!)
+          : fetch,
+      });
+      const agentCard = await resolver.resolve(baseUrl, path);
 
-      const targetAgentId = typeof (message as any)?.agentId === "string" ? String((message as any).agentId) : "";
+      // Build transport list: main URL + additionalInterfaces
+      const mainTransport = agentCard.preferredTransport ?? "JSONRPC";
+      const allInterfaces: TransportEndpoint[] = [
+        { url: agentCard.url, transport: mainTransport },
+      ];
 
-      const outboundMessage: any = {
-        kind: "message",
-        messageId: (message.messageId as string) || uuidv4(),
-        role: (message.role as Message["role"]) || "user",
-        parts: (message.parts as Message["parts"]) || [
-          { kind: "text", text: String(message.text || message.message || "") },
-        ],
-      };
-
-      // OpenClaw extension: allow per-message routing to a specific agentId on the peer.
-      // Note: gRPC transport uses protobuf Message and may drop unknown fields.
-      if (targetAgentId) {
-        outboundMessage.agentId = targetAgentId;
-      }
-
-      const sendParams: MessageSendParams = {
-        message: outboundMessage,
-      };
-
-      const serviceParameters: Record<string, string> = {};
-      if (peer.auth?.token) {
-        if (peer.auth.type === "bearer") {
-          serviceParameters.authorization = `Bearer ${peer.auth.token}`;
-        } else {
-          serviceParameters["x-api-key"] = peer.auth.token;
+      if (agentCard.additionalInterfaces) {
+        for (const iface of agentCard.additionalInterfaces) {
+          // Avoid duplicate of the main endpoint
+          if (iface.url !== agentCard.url || iface.transport !== mainTransport) {
+            allInterfaces.push({ url: iface.url, transport: iface.transport });
+          }
         }
       }
 
-      const result = await client.sendMessage(sendParams, {
-        serviceParameters: Object.keys(serviceParameters).length ? serviceParameters : undefined,
+      transports = orderTransports(allInterfaces);
+    } catch {
+      // Card resolution failed — fall back to single-transport path
+      // (let the SDK pick whatever it can)
+      transports = [];
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Fallback loop: try each transport in priority order
+    // ------------------------------------------------------------------
+    if (transports.length <= 1) {
+      // No fallback candidates — use original single-transport path
+      return this.doSendViaFactory(factory, baseUrl, path, sendParams, requestOptions);
+    }
+
+    let lastError: unknown;
+    for (let i = 0; i < transports.length; i++) {
+      const endpoint = transports[i];
+
+      log?.("info", "transport.try", {
+        peer: peer.name,
+        transport: endpoint.transport,
+        url: endpoint.url,
+        attempt: i + 1,
+        total: transports.length,
       });
 
+      try {
+        const result = await this.doSendViaTransport(
+          peer,
+          endpoint,
+          sendParams,
+          requestOptions,
+        );
+
+        // Success or non-retryable failure → return immediately
+        if (result.ok || !isRetryableTransportError(result)) {
+          if (i > 0) {
+            log?.("info", "transport.fallback.success", {
+              peer: peer.name,
+              transport: endpoint.transport,
+              url: endpoint.url,
+              attemptIndex: i,
+            });
+          }
+          return result;
+        }
+
+        // Retryable failure — try next transport
+        lastError = result;
+        log?.("warn", "transport.fallback", {
+          peer: peer.name,
+          failedTransport: endpoint.transport,
+          statusCode: result.statusCode,
+          error: (result.response as any)?.error,
+        });
+      } catch (error: unknown) {
+        if (!isRetryableTransportError(error)) {
+          // Non-retryable error (auth, protocol) → stop immediately
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          return {
+            ok: false,
+            statusCode: 500,
+            response: { error: errorMessage },
+          };
+        }
+
+        // Retryable error — try next transport
+        lastError = error;
+        log?.("warn", "transport.fallback", {
+          peer: peer.name,
+          failedTransport: endpoint.transport,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    // All transports exhausted
+    const errorMessage = lastError instanceof Error
+      ? lastError.message
+      : typeof lastError === "object" && lastError && "response" in lastError
+        ? ((lastError as any).response as any)?.error ?? String(lastError)
+        : String(lastError);
+
+    return {
+      ok: false,
+      statusCode: 500,
+      response: { error: `All transports failed for peer "${peer.name}": ${errorMessage}` },
+    };
+  }
+
+  /**
+   * Send via the SDK's ClientFactory (original single-transport path).
+   */
+  private async doSendViaFactory(
+    factory: ClientFactory,
+    baseUrl: string,
+    path: string,
+    sendParams: MessageSendParams,
+    requestOptions: { serviceParameters?: Record<string, string> },
+  ): Promise<OutboundSendResult> {
+    try {
+      const client = await factory.createFromUrl(baseUrl, path);
+      const result = await client.sendMessage(sendParams, requestOptions);
       return {
         ok: true,
         statusCode: 200,
@@ -209,6 +353,59 @@ export class A2AClient {
         statusCode: 500,
         response: { error: errorMessage },
       };
+    }
+  }
+
+  /**
+   * Send via a specific transport endpoint, creating the transport directly.
+   */
+  private async doSendViaTransport(
+    peer: PeerConfig,
+    endpoint: TransportEndpoint,
+    sendParams: MessageSendParams,
+    requestOptions: { serviceParameters?: Record<string, string> },
+  ): Promise<OutboundSendResult> {
+    const authHandler = createAuthHandler(peer);
+    const authFetch = authHandler
+      ? createAuthenticatingFetchWithRetry(fetch, authHandler)
+      : fetch;
+
+    let transport;
+
+    switch (endpoint.transport) {
+      case "JSONRPC": {
+        const factory = new JsonRpcTransportFactory({ fetchImpl: authFetch });
+        transport = await factory.create(endpoint.url, {} as any);
+        break;
+      }
+      case "HTTP+JSON": {
+        const factory = new RestTransportFactory({ fetchImpl: authFetch });
+        transport = await factory.create(endpoint.url, {} as any);
+        break;
+      }
+      case "GRPC": {
+        const factory = new GrpcTransportFactory();
+        transport = await factory.create(endpoint.url, {} as any);
+        break;
+      }
+      default:
+        return {
+          ok: false,
+          statusCode: 500,
+          response: { error: `Unsupported transport: ${endpoint.transport}` },
+        };
+    }
+
+    try {
+      const result = await transport.sendMessage(sendParams, requestOptions);
+      return {
+        ok: true,
+        statusCode: 200,
+        response: result as unknown as Record<string, unknown>,
+      };
+    } catch (error: unknown) {
+      // Re-throw so the fallback loop can classify the error
+      throw error;
     }
   }
 }

--- a/src/transport-fallback.ts
+++ b/src/transport-fallback.ts
@@ -1,0 +1,105 @@
+/**
+ * Transport fallback helpers for A2A outbound sends.
+ *
+ * When a peer's Agent Card advertises multiple transports via
+ * `additionalInterfaces`, this module provides utilities to order
+ * them by priority and to decide whether a send error is retryable
+ * at the transport level (as opposed to auth / protocol errors that
+ * would fail identically on every transport).
+ */
+
+// ---------------------------------------------------------------------------
+// Transport priority
+// ---------------------------------------------------------------------------
+
+/** Canonical transport protocol names from the A2A v0.3.0 spec. */
+export type TransportPriority = "JSONRPC" | "HTTP+JSON" | "GRPC";
+
+/** Fallback order: JSON-RPC first, REST second, gRPC last. */
+const PRIORITY_ORDER: readonly string[] = ["JSONRPC", "HTTP+JSON", "GRPC"];
+
+export interface TransportEndpoint {
+  url: string;
+  transport: string;
+}
+
+/**
+ * Sort transport endpoints by priority (JSON-RPC > REST > gRPC).
+ * Unknown transports are appended at the end in their original order.
+ */
+export function orderTransports(interfaces: TransportEndpoint[]): TransportEndpoint[] {
+  const known: TransportEndpoint[] = [];
+  const unknown: TransportEndpoint[] = [];
+
+  // Bucket by known vs unknown
+  for (const iface of interfaces) {
+    if (PRIORITY_ORDER.includes(iface.transport)) {
+      known.push(iface);
+    } else {
+      unknown.push(iface);
+    }
+  }
+
+  // Sort known by priority index
+  known.sort(
+    (a, b) => PRIORITY_ORDER.indexOf(a.transport) - PRIORITY_ORDER.indexOf(b.transport),
+  );
+
+  return [...known, ...unknown];
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the error indicates a transport-level problem that
+ * could succeed on a different transport (connection refused, timeout, 5xx).
+ *
+ * Auth errors (401/403) and A2A protocol errors are NOT retryable because
+ * they would fail identically on every transport.
+ */
+export function isRetryableTransportError(error: unknown): boolean {
+  if (!error) return false;
+
+  // Fetch / network errors thrown as Error objects
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    return (
+      msg.includes("econnrefused") ||
+      msg.includes("econnreset") ||
+      msg.includes("etimedout") ||
+      msg.includes("epipe") ||
+      msg.includes("fetch failed") ||
+      msg.includes("network") ||
+      msg.includes("socket") ||
+      msg.includes("abort") ||
+      msg.includes("timeout") ||
+      msg.includes("timed out") ||
+      msg.includes("dns") ||
+      msg.includes("enotfound") ||
+      // gRPC transport errors
+      msg.includes("unavailable") ||
+      msg.includes("deadline exceeded")
+    );
+  }
+
+  // HTTP response-like objects with a status code
+  if (
+    error &&
+    typeof error === "object" &&
+    "statusCode" in error &&
+    typeof (error as any).statusCode === "number"
+  ) {
+    const code = (error as any).statusCode as number;
+    // 5xx = server error → could be transport-specific → retry
+    // 429 = rate limit → transport-specific → retry
+    if (code >= 500 || code === 429) return true;
+    // 401/403 = auth → would fail on all transports → no retry
+    // Other 4xx = client error → no retry
+    return false;
+  }
+
+  // Unknown shape → not retryable (be conservative)
+  return false;
+}

--- a/tests/transport-fallback.test.ts
+++ b/tests/transport-fallback.test.ts
@@ -1,0 +1,318 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  orderTransports,
+  isRetryableTransportError,
+  type TransportEndpoint,
+} from "../src/transport-fallback.js";
+
+// ---------------------------------------------------------------------------
+// orderTransports
+// ---------------------------------------------------------------------------
+
+describe("orderTransports", () => {
+  it("returns correct priority order: JSONRPC > HTTP+JSON > GRPC", () => {
+    const input: TransportEndpoint[] = [
+      { url: "http://x:50051", transport: "GRPC" },
+      { url: "http://x/rest", transport: "HTTP+JSON" },
+      { url: "http://x/jsonrpc", transport: "JSONRPC" },
+    ];
+
+    const result = orderTransports(input);
+
+    assert.equal(result[0].transport, "JSONRPC");
+    assert.equal(result[1].transport, "HTTP+JSON");
+    assert.equal(result[2].transport, "GRPC");
+  });
+
+  it("preserves order when only one transport exists", () => {
+    const input: TransportEndpoint[] = [
+      { url: "http://x/jsonrpc", transport: "JSONRPC" },
+    ];
+
+    const result = orderTransports(input);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].transport, "JSONRPC");
+  });
+
+  it("appends unknown transports at the end", () => {
+    const input: TransportEndpoint[] = [
+      { url: "http://x/custom", transport: "WEBSOCKET" },
+      { url: "http://x/rest", transport: "HTTP+JSON" },
+      { url: "http://x/jsonrpc", transport: "JSONRPC" },
+    ];
+
+    const result = orderTransports(input);
+
+    assert.equal(result[0].transport, "JSONRPC");
+    assert.equal(result[1].transport, "HTTP+JSON");
+    assert.equal(result[2].transport, "WEBSOCKET");
+  });
+
+  it("handles empty array", () => {
+    const result = orderTransports([]);
+    assert.equal(result.length, 0);
+  });
+
+  it("handles duplicates correctly", () => {
+    const input: TransportEndpoint[] = [
+      { url: "http://a/jsonrpc", transport: "JSONRPC" },
+      { url: "http://b/jsonrpc", transport: "JSONRPC" },
+      { url: "http://a/rest", transport: "HTTP+JSON" },
+    ];
+
+    const result = orderTransports(input);
+
+    // Both JSONRPC entries come before HTTP+JSON
+    assert.equal(result[0].transport, "JSONRPC");
+    assert.equal(result[1].transport, "JSONRPC");
+    assert.equal(result[2].transport, "HTTP+JSON");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isRetryableTransportError
+// ---------------------------------------------------------------------------
+
+describe("isRetryableTransportError", () => {
+  // -- Retryable errors --
+
+  it("returns true for ECONNREFUSED", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("connect ECONNREFUSED 127.0.0.1:18800")),
+      true,
+    );
+  });
+
+  it("returns true for ECONNRESET", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("read ECONNRESET")),
+      true,
+    );
+  });
+
+  it("returns true for ETIMEDOUT", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("connect ETIMEDOUT 10.0.0.1:443")),
+      true,
+    );
+  });
+
+  it("returns true for fetch failed", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("fetch failed")),
+      true,
+    );
+  });
+
+  it("returns true for timeout errors", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("The operation timed out")),
+      true,
+    );
+  });
+
+  it("returns true for DNS / ENOTFOUND errors", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("getaddrinfo ENOTFOUND example.com")),
+      true,
+    );
+  });
+
+  it("returns true for gRPC UNAVAILABLE", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("14 UNAVAILABLE: Connection refused")),
+      true,
+    );
+  });
+
+  it("returns true for gRPC DEADLINE_EXCEEDED", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("4 DEADLINE EXCEEDED")),
+      true,
+    );
+  });
+
+  it("returns true for 500 status code object", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 500, response: { error: "Internal" } }),
+      true,
+    );
+  });
+
+  it("returns true for 502 status code object", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 502, response: { error: "Bad Gateway" } }),
+      true,
+    );
+  });
+
+  it("returns true for 503 status code object", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 503, response: { error: "Unavailable" } }),
+      true,
+    );
+  });
+
+  it("returns true for 429 rate limit", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 429, response: { error: "Too Many Requests" } }),
+      true,
+    );
+  });
+
+  // -- Non-retryable errors --
+
+  it("returns false for 401 Unauthorized", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 401, response: { error: "Unauthorized" } }),
+      false,
+    );
+  });
+
+  it("returns false for 403 Forbidden", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 403, response: { error: "Forbidden" } }),
+      false,
+    );
+  });
+
+  it("returns false for 400 Bad Request", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 400, response: { error: "Bad Request" } }),
+      false,
+    );
+  });
+
+  it("returns false for 404 Not Found", () => {
+    assert.equal(
+      isRetryableTransportError({ statusCode: 404, response: { error: "Not Found" } }),
+      false,
+    );
+  });
+
+  it("returns false for non-network Error", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("Invalid argument")),
+      false,
+    );
+  });
+
+  it("returns false for auth-related Error messages", () => {
+    assert.equal(
+      isRetryableTransportError(new Error("Authentication required")),
+      false,
+    );
+  });
+
+  it("returns false for null", () => {
+    assert.equal(isRetryableTransportError(null), false);
+  });
+
+  it("returns false for undefined", () => {
+    assert.equal(isRetryableTransportError(undefined), false);
+  });
+
+  it("returns false for unknown object shape", () => {
+    assert.equal(isRetryableTransportError({ foo: "bar" }), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-style: transport fallback scenario in A2AClient
+// ---------------------------------------------------------------------------
+// These tests exercise the fallback logic indirectly via the exported helpers,
+// simulating what the A2AClient.doSendMessage method does internally.
+
+describe("transport fallback scenario", () => {
+  it("first transport fails with connection error, second succeeds", async () => {
+    const transports: TransportEndpoint[] = orderTransports([
+      { url: "http://peer:8080/jsonrpc", transport: "JSONRPC" },
+      { url: "http://peer:8080/rest", transport: "HTTP+JSON" },
+    ]);
+
+    const sendResults: Array<{ ok: boolean; error?: string }> = [
+      { ok: false, error: "ECONNREFUSED" }, // JSONRPC fails
+      { ok: true },                          // REST succeeds
+    ];
+
+    let usedTransport: string | undefined;
+    let attempts = 0;
+
+    for (let i = 0; i < transports.length; i++) {
+      const endpoint = transports[i];
+      attempts++;
+
+      const simulated = sendResults[i];
+      if (!simulated.ok) {
+        const err = new Error(simulated.error!);
+        if (isRetryableTransportError(err)) {
+          continue; // Fall back to next transport
+        }
+        // Non-retryable → stop
+        break;
+      }
+
+      usedTransport = endpoint.transport;
+      break;
+    }
+
+    assert.equal(attempts, 2);
+    assert.equal(usedTransport, "HTTP+JSON");
+  });
+
+  it("does not fall back on auth error (401)", async () => {
+    const transports: TransportEndpoint[] = orderTransports([
+      { url: "http://peer:8080/jsonrpc", transport: "JSONRPC" },
+      { url: "http://peer:8080/rest", transport: "HTTP+JSON" },
+    ]);
+
+    let attempts = 0;
+
+    for (let i = 0; i < transports.length; i++) {
+      attempts++;
+
+      // Simulate 401 on first transport
+      const err = { statusCode: 401, response: { error: "Unauthorized" } };
+      if (isRetryableTransportError(err)) {
+        continue;
+      }
+      break; // 401 is NOT retryable → stop
+    }
+
+    assert.equal(attempts, 1, "should stop after auth error, no fallback");
+  });
+
+  it("all transports fail → returns the last error", async () => {
+    const transports: TransportEndpoint[] = orderTransports([
+      { url: "http://peer:8080/jsonrpc", transport: "JSONRPC" },
+      { url: "http://peer:8080/rest", transport: "HTTP+JSON" },
+      { url: "http://peer:50051", transport: "GRPC" },
+    ]);
+
+    const errors = [
+      new Error("ECONNREFUSED"),
+      new Error("fetch failed"),
+      new Error("UNAVAILABLE"),
+    ];
+
+    let lastError: Error | undefined;
+    let allFailed = true;
+
+    for (let i = 0; i < transports.length; i++) {
+      const err = errors[i];
+      lastError = err;
+
+      if (isRetryableTransportError(err)) {
+        continue;
+      }
+      allFailed = false;
+      break;
+    }
+
+    assert.equal(allFailed, true, "all transports should have failed");
+    assert.ok(lastError);
+    assert.ok(lastError.message.includes("UNAVAILABLE"));
+  });
+});


### PR DESCRIPTION
## Summary

- When a peer's Agent Card advertises multiple transports via `additionalInterfaces`, outbound sends now automatically fall back through transports in priority order: **JSON-RPC → REST → gRPC**
- Only connection errors, timeouts, and 5xx errors trigger fallback; auth errors (401/403) and A2A protocol errors stop immediately
- Closes roadmap item: "Automatic transport fallback (JSON-RPC → REST/gRPC)"

## Changes

- `src/transport-fallback.ts`: New module with `orderTransports()` priority sorting and `isRetryableTransportError()` error classification
- `src/client.ts`: Refactored `doSendMessage()` to resolve Agent Card → extract transports → try in priority order with fallback
- `tests/transport-fallback.test.ts`: 29 new tests (ordering, error classification, fallback scenarios)
- `README.md`: Move roadmap item to Completed

## Test plan

- [x] 29/29 new tests pass
- [x] 194/194 total tests pass (zero regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)