### PR TITLE
fix(task-store): tolerate Windows EPERM/EACCES rename during atomic save

### DIFF
--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -42,7 +42,41 @@ export class FileTaskStore implements TaskStore {
     const payload = `${JSON.stringify(nextTask, null, 2)}\n`;
 
     await writeFile(tmpPath, payload, "utf8");
-    await rename(tmpPath, targetPath);
+
+    // Windows: atomic rename can intermittently fail with EPERM/EACCES when the
+    // destination file is being scanned/read. This breaks task polling.
+    // Prefer rename (atomic), but fall back to direct write with cleanup.
+    try {
+      await rename(tmpPath, targetPath);
+      return;
+    } catch (error: unknown) {
+      const code = (error as { code?: string } | undefined)?.code;
+      if (code !== "EPERM" && code !== "EACCES") {
+        throw error;
+      }
+
+      // Retry a few times with small backoff; then fall back to overwrite.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+          await new Promise((r) => setTimeout(r, 25 * (attempt + 1)));
+          await rename(tmpPath, targetPath);
+          return;
+        } catch (retryError: unknown) {
+          const retryCode = (retryError as { code?: string } | undefined)?.code;
+          if (retryCode !== "EPERM" && retryCode !== "EACCES") {
+            throw retryError;
+          }
+        }
+      }
+
+      // Non-atomic fallback (best-effort).
+      await writeFile(targetPath, payload, "utf8");
+      try {
+        await unlink(tmpPath);
+      } catch {
+        // ignore
+      }
+    }
   }
 
   /** List all stored task IDs. */


### PR DESCRIPTION
fix(task-store): tolerate intermittent Windows EPERM/EACCES rename failures when saving tasks

---

## Summary

On Windows (especially in corporate environments with antivirus / file indexers / DLP), atomic `rename(tmp -> target)` can intermittently fail with `EPERM`/`EACCES`. When this happens inside the A2A gateway task store, the durable task state cannot be persisted and long-running A2A flows (async task mode, `--non-blocking --wait` / `tasks/get`) become unreliable.

This PR makes `FileTaskStore.save()` more resilient:
- keep atomic rename as the fast/primary path
- when rename fails with `EPERM`/`EACCES`, retry a few times with small backoff
- if it still fails, fall back to a best-effort non-atomic overwrite write, and clean up the tmp file

This changes a hard failure into a recoverable path so polling can continue.

---

## Why this matters

A2A async task mode relies on being able to persist incremental task states. A single failure to write the task JSON can break polling and make agent-to-agent messaging appear flaky.

---

## Repro (Windows)

1) Run A2A Gateway on Windows.
2) Trigger async tasks at a moderate rate (or concurrently), especially on a machine with active antivirus/indexing.
3) This is easiest to reproduce when running multiple OpenClaw profiles on the same machine/user (shared task store directory), but the underlying file-lock race can also happen in single-gateway setups.
4) Observe intermittent:

```
EPERM: operation not permitted, rename '<task>.json.<pid>.<ts>.tmp' -> '<task>.json'
```

---

## Fix

`src/task-store.ts`:
- wrap `rename(tmp, target)` in a try/catch
- only handle `EPERM`/`EACCES`
- short backoff retries
- fallback to `writeFile(target, payload)` + best-effort tmp cleanup

---

## Deployment / config note (recommended)

When running multiple OpenClaw profiles on the same Windows user, do not share the default task store directory.

Recommend configuring per-profile:
- `plugins.entries.a2a-gateway.config.storage.tasksDir`

Example:

```json
{
  "plugins": {
    "entries": {
      "a2a-gateway": {
        "config": {
          "storage": {
            "tasksDir": "C:/Users/<user>/.openclaw-<profile>/a2a-tasks"
          }
        }
      }
    }
  }
}
```

This reduces cross-profile collisions and further improves stability.

---

## Testing

- `npx tsc --noEmit`
- `npm test`

CI already runs on ubuntu; the change is isolated and should be platform-safe.
