### PR TITLE
feat: Hill equation affinity scoring for routing rules

### DIFF
--- a/src/routing-rules.ts
+++ b/src/routing-rules.ts
@@ -2,7 +2,14 @@
  * Rule-based routing — choose peer + agentId based on message content.
  *
  * Rules are evaluated at send-time in priority order (higher priority first).
- * The first matching rule wins.
+ * The first matching rule wins (legacy). When {@link AffinityConfig} is
+ * provided, rules are scored using the Hill equation (Hill, 1910) and
+ * returned in descending score order.
+ *
+ * @see Hill, A.V. (1910) "The possible effects of the aggregation of the
+ *   molecules of haemoglobin on its dissociation curves." J Physiol 40, iv–vii.
+ * @see Finlay, D.B. et al. (2020) "100 years of modelling ligand-receptor
+ *   binding and response." Br J Pharmacol 177(7):1472-1484.
  */
 
 // ---------------------------------------------------------------------------
@@ -30,6 +37,53 @@ export interface RoutingRule {
 export interface RoutingMatch {
   peer: string;
   agentId?: string;
+}
+
+/**
+ * Configuration for Hill-equation-based affinity scoring.
+ *
+ * When provided to {@link matchAllRules}, each matching rule is scored using:
+ *
+ *   score = affinity^n / (Kd^n + affinity^n)
+ *
+ * where `affinity` is a weighted combination of match dimensions.
+ */
+export interface AffinityConfig {
+  /**
+   * Hill coefficient (n). Controls the steepness of the scoring sigmoid.
+   * - n = 1: linear response (Michaelis-Menten, equivalent to legacy behavior)
+   * - n > 1: threshold effect ("good enough" peers strongly preferred)
+   * - n < 1: dispersive (spreads load more evenly)
+   * @default 1
+   */
+  hillCoefficient?: number;
+  /**
+   * Half-saturation constant. When affinity equals Kd, score = 0.5.
+   * Lower Kd → stricter (high-affinity receptor analogy).
+   * @default 0.5
+   */
+  kd?: number;
+  /** Per-dimension weights (must sum to ~1 for interpretability). */
+  weights?: AffinityWeights;
+}
+
+export interface AffinityWeights {
+  /** Weight for skill match ratio (matched / required). @default 0.4 */
+  skills?: number;
+  /** Weight for tag match ratio (matched / required). @default 0.3 */
+  tags?: number;
+  /** Weight for pattern match (1 if matched, 0 if not). @default 0.2 */
+  pattern?: number;
+  /** Weight for historical success rate of the peer. @default 0.1 */
+  successRate?: number;
+}
+
+/**
+ * A routing match extended with a Hill-equation affinity score.
+ */
+export interface ScoredMatch extends RoutingMatch {
+  /** Hill score in [0, 1]. Higher = better affinity. */
+  score: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,8 +154,159 @@ export function parseRoutingRules(raw: unknown): RoutingRule[] {
 }
 
 // ---------------------------------------------------------------------------
+// Hill equation — pure math
+// ---------------------------------------------------------------------------
+
+const DEFAULT_N = 1;
+const DEFAULT_KD = 0.5;
+const DEFAULT_WEIGHTS: Required<AffinityWeights> = {
+  skills: 0.4,
+  tags: 0.3,
+  pattern: 0.2,
+  successRate: 0.1,
+};
+
+/**
+ * Hill equation: score = affinity^n / (Kd^n + affinity^n)
+ *
+ * When affinity = Kd, score = 0.5 (half-saturation, by definition).
+ *
+ * @param affinity  Raw affinity value in [0, 1].
+ * @param n         Hill coefficient (steepness). n=1 → Michaelis-Menten.
+ * @param kd        Half-saturation constant.
+ * @returns Score in [0, 1].
+ *
+ * @see Hill, A.V. (1910) J Physiol 40, iv–vii.
+ */
+export function hillScore(affinity: number, n: number, kd: number): number {
+  if (affinity <= 0) return 0;
+  if (kd <= 0) return affinity > 0 ? 1 : 0;
+  const an = affinity ** n;
+  const kn = kd ** n;
+  return an / (kn + an);
+}
+
+// ---------------------------------------------------------------------------
+// Affinity computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute raw affinity for a (rule, message, peer) triple.
+ *
+ * Affinity is a weighted sum of per-dimension match ratios:
+ *   - skill_match_ratio:  matched skills / required skills   (0-1)
+ *   - tag_match_ratio:    matched tags / required tags       (0-1)
+ *   - pattern_match:      regex matched = 1, else 0
+ *   - success_rate:       historical success rate            (0-1, optional)
+ *
+ * Dimensions that are not specified in the rule contribute their full
+ * weight (1.0), so a rule with only `pattern` set gets pattern + full
+ * credit for skills and tags.  This keeps simple rules competitive.
+ */
+export function computeAffinity(
+  rule: RoutingRule,
+  message: { text: string; tags?: string[] },
+  peerSkills?: Map<string, string[]>,
+  successRates?: Map<string, number>,
+  weights?: AffinityWeights,
+): number {
+  const w = { ...DEFAULT_WEIGHTS, ...weights };
+
+  // --- skill match ratio ---
+  let skillRatio = 1; // default: full credit when not specified
+  if (rule.match.skills && rule.match.skills.length > 0) {
+    const peerSet = peerSkills?.get(rule.target.peer) ?? [];
+    const matched = rule.match.skills.filter((s) => peerSet.includes(s)).length;
+    skillRatio = matched / rule.match.skills.length;
+  }
+
+  // --- tag match ratio ---
+  let tagRatio = 1;
+  if (rule.match.tags && rule.match.tags.length > 0) {
+    const msgTags = message.tags ?? [];
+    const matched = rule.match.tags.filter((t) => msgTags.includes(t)).length;
+    tagRatio = matched / rule.match.tags.length;
+  }
+
+  // --- pattern match ---
+  let patternMatch = 1; // default: full credit when not specified
+  if (rule.match.pattern) {
+    if (rule.match.pattern.length > 500) {
+      patternMatch = 0;
+    } else {
+      try {
+        const re = new RegExp(rule.match.pattern, "i");
+        patternMatch = re.test(message.text.slice(0, 10_000)) ? 1 : 0;
+      } catch {
+        patternMatch = 0;
+      }
+    }
+  }
+
+  // --- success rate ---
+  const successRate = successRates?.get(rule.target.peer) ?? 1;
+
+  return (
+    w.skills * skillRatio +
+    w.tags * tagRatio +
+    w.pattern * patternMatch +
+    w.successRate * successRate
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Matching
 // ---------------------------------------------------------------------------
+
+/**
+ * Score all matching rules using Hill-equation affinity.
+ *
+ * When `affinityConfig` is **not** provided, behaviour is identical to the
+ * legacy priority-first model: matching rules are returned in priority
+ * order with score = 1 for all (backward-compatible).
+ *
+ * When `affinityConfig` **is** provided, each rule that passes the boolean
+ * AND-gate ({@link matchesRule}) is scored via {@link hillScore} over its
+ * {@link computeAffinity} value, and results are sorted by score descending.
+ *
+ * @returns Scored matches, highest score first.
+ */
+export function matchAllRules(
+  rules: RoutingRule[],
+  message: { text: string; tags?: string[] },
+  peerSkills?: Map<string, string[]>,
+  successRates?: Map<string, number>,
+  affinityConfig?: AffinityConfig,
+): ScoredMatch[] {
+  const scored: ScoredMatch[] = [];
+
+  for (const rule of rules) {
+    if (!matchesRule(rule, message, peerSkills)) continue;
+
+    const match: RoutingMatch = {
+      peer: rule.target.peer,
+      ...(rule.target.agentId ? { agentId: rule.target.agentId } : {}),
+    };
+
+    if (!affinityConfig) {
+      // Legacy mode: score = 1 (priority order preserved from parseRoutingRules)
+      scored.push({ ...match, score: 1 });
+    } else {
+      const n = affinityConfig.hillCoefficient ?? DEFAULT_N;
+      const kd = affinityConfig.kd ?? DEFAULT_KD;
+      const raw = computeAffinity(rule, message, peerSkills, successRates, affinityConfig.weights);
+      scored.push({ ...match, score: hillScore(raw, n, kd) });
+    }
+  }
+
+  // When using affinity scoring, sort by score descending.
+  // In legacy mode all scores are 1 so original priority order is preserved.
+  if (affinityConfig) {
+    scored.sort((a, b) => b.score - a.score);
+  }
+
+  return scored;
+}
 
 /**
  * Evaluate rules in priority order against a message.
@@ -122,16 +327,11 @@ export function matchRule(
   message: { text: string; tags?: string[] },
   peerSkills?: Map<string, string[]>,
 ): RoutingMatch | null {
-  for (const rule of rules) {
-    if (!matchesRule(rule, message, peerSkills)) continue;
-
-    return {
-      peer: rule.target.peer,
-      ...(rule.target.agentId ? { agentId: rule.target.agentId } : {}),
-    };
-  }
-
-  return null;
+  // Backward-compatible: no affinity scoring, priority-first.
+  const results = matchAllRules(rules, message, peerSkills);
+  if (results.length === 0) return null;
+  const { score: _, ...match } = results[0];
+  return match;
 }
 
 /**

--- a/tests/routing-rules.test.ts
+++ b/tests/routing-rules.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { parseRoutingRules, matchRule } from "../src/routing-rules.js";
-import type { RoutingRule } from "../src/routing-rules.js";
+import {
+  parseRoutingRules,
+  matchRule,
+  hillScore,
+  computeAffinity,
+  matchAllRules,
+} from "../src/routing-rules.js";
+import type { RoutingRule, AffinityConfig, ScoredMatch } from "../src/routing-rules.js";
 import { parseConfig } from "../index.js";
 import { createHarness, invokeGatewayMethod, makeConfig } from "./helpers.js";
 
@@ -431,5 +437,208 @@ describe("a2a.send — rule-based routing", () => {
       String(data.error).includes("Peer not found: ExplicitPeer"),
       `Expected 'Peer not found' error but got: ${data.error}`,
     );
+  });
+});
+
+// ===========================================================================
+// Hill equation affinity scoring (Phase 1.1 — Bio-inspired routing)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// hillScore — pure math (Hill 1910)
+// ---------------------------------------------------------------------------
+
+describe("hillScore — Hill equation math", () => {
+  it("half-saturation: hillScore(Kd, n, Kd) === 0.5 for any n", () => {
+    assert.equal(hillScore(0.5, 1, 0.5), 0.5);
+    assert.equal(hillScore(0.5, 2, 0.5), 0.5);
+    assert.equal(hillScore(0.5, 3, 0.5), 0.5);
+  });
+
+  it("full saturation: hillScore(1, n, Kd) approaches 1", () => {
+    // hillScore(1, 2, 0.5) = 1/(0.25+1) = 0.8; higher n → closer to 1
+    assert.ok(hillScore(1, 2, 0.5) === 0.8, `Expected 0.8, got ${hillScore(1, 2, 0.5)}`);
+    assert.ok(hillScore(1, 4, 0.5) > 0.9, `n=4 should give > 0.9`);
+  });
+
+  it("zero affinity: hillScore(0, n, Kd) === 0", () => {
+    assert.equal(hillScore(0, 1, 0.5), 0);
+    assert.equal(hillScore(0, 3, 0.5), 0);
+  });
+
+  it("higher n gives steeper sigmoid: score at 0.8 with n=3 > n=1", () => {
+    const s1 = hillScore(0.8, 1, 0.5);
+    const s3 = hillScore(0.8, 3, 0.5);
+    assert.ok(s3 > s1, `n=3 score ${s3} should be > n=1 score ${s1}`);
+  });
+
+  it("lower n gives gentler curve: score at 0.3 with n=0.5 > n=2", () => {
+    const s05 = hillScore(0.3, 0.5, 0.5);
+    const s2 = hillScore(0.3, 2, 0.5);
+    assert.ok(s05 > s2, `n=0.5 score ${s05} should be > n=2 score ${s2}`);
+  });
+
+  it("score is always in [0, 1] range", () => {
+    for (const a of [0, 0.1, 0.5, 0.9, 1.0]) {
+      for (const n of [0.5, 1, 2, 3]) {
+        const s = hillScore(a, n, 0.5);
+        assert.ok(s >= 0 && s <= 1, `hillScore(${a}, ${n}, 0.5) = ${s} out of range`);
+      }
+    }
+  });
+
+  it("n=1 gives linear-like response (equivalent to Michaelis-Menten)", () => {
+    // At n=1: score = a / (Kd + a). With Kd=0.5, score(0.25) ≈ 0.333
+    const s = hillScore(0.25, 1, 0.5);
+    assert.ok(Math.abs(s - 1 / 3) < 0.001, `Expected ~0.333, got ${s}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeAffinity — weighted combination
+// ---------------------------------------------------------------------------
+
+describe("computeAffinity — affinity calculation", () => {
+  it("full skill match gives high affinity", () => {
+    const rule: RoutingRule = parseRoutingRules([
+      { name: "r", match: { skills: ["a", "b", "c"] }, target: { peer: "P" } },
+    ])[0];
+    const peerSkills = new Map([["P", ["a", "b", "c"]]]);
+    const a = computeAffinity(rule, { text: "" }, peerSkills);
+    assert.ok(a > 0.3, `Expected > 0.3, got ${a}`);
+  });
+
+  it("partial skill match gives lower affinity than full match", () => {
+    const rule: RoutingRule = parseRoutingRules([
+      { name: "r", match: { skills: ["a", "b", "c"] }, target: { peer: "P" } },
+    ])[0];
+    const full = new Map([["P", ["a", "b", "c"]]]);
+    const partial = new Map([["P", ["a"]]]);
+    const aFull = computeAffinity(rule, { text: "" }, full);
+    const aPartial = computeAffinity(rule, { text: "" }, partial);
+    assert.ok(aFull > aPartial, `Full ${aFull} should be > partial ${aPartial}`);
+  });
+
+  it("pattern match contributes to affinity", () => {
+    const rule: RoutingRule = parseRoutingRules([
+      { name: "r", match: { pattern: "hello" }, target: { peer: "P" } },
+    ])[0];
+    const withMatch = computeAffinity(rule, { text: "hello world" });
+    const noMatch = computeAffinity(rule, { text: "goodbye" });
+    assert.ok(withMatch > noMatch, `Match ${withMatch} should be > no match ${noMatch}`);
+  });
+
+  it("tag match ratio is proportional", () => {
+    const rule: RoutingRule = parseRoutingRules([
+      { name: "r", match: { tags: ["a", "b", "c"] }, target: { peer: "P" } },
+    ])[0];
+    const a3 = computeAffinity(rule, { text: "", tags: ["a", "b", "c"] });
+    const a1 = computeAffinity(rule, { text: "", tags: ["a"] });
+    assert.ok(a3 > a1, `3-tag match ${a3} should be > 1-tag match ${a1}`);
+  });
+
+  it("custom weights override defaults", () => {
+    const rule: RoutingRule = parseRoutingRules([
+      { name: "r", match: { pattern: "test", skills: ["x"] }, target: { peer: "P" } },
+    ])[0];
+    const peerSkills = new Map([["P", ["x"]]]);
+    // Skill weight = 1.0, everything else = 0 → affinity = skill_ratio
+    const a = computeAffinity(rule, { text: "test" }, peerSkills, undefined, {
+      skills: 1.0,
+      tags: 0,
+      pattern: 0,
+      successRate: 0,
+    });
+    assert.ok(Math.abs(a - 1.0) < 0.01, `Expected ~1.0 with skill-only weights, got ${a}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchAllRules — scored multi-match
+// ---------------------------------------------------------------------------
+
+describe("matchAllRules — scored routing", () => {
+  const rules: RoutingRule[] = parseRoutingRules([
+    { name: "specialist", match: { skills: ["deep-code"] }, target: { peer: "Expert" }, priority: 5 },
+    { name: "generalist", match: { pattern: ".*" }, target: { peer: "General" }, priority: 10 },
+  ]);
+
+  it("returns scored results sorted by score descending", () => {
+    const peerSkills = new Map([["Expert", ["deep-code", "review"]]]);
+    const config: AffinityConfig = { hillCoefficient: 2, kd: 0.5 };
+    const results = matchAllRules(rules, { text: "review code" }, peerSkills, undefined, config);
+    assert.ok(results.length > 0, "Should have results");
+    // All results should have score property
+    for (const r of results) {
+      assert.ok(typeof r.score === "number", `score should be number, got ${typeof r.score}`);
+      assert.ok(r.score >= 0 && r.score <= 1, `score ${r.score} out of [0,1]`);
+    }
+    // Results sorted by score descending
+    for (let i = 1; i < results.length; i++) {
+      assert.ok(results[i - 1].score >= results[i].score,
+        `Results not sorted: ${results[i - 1].score} < ${results[i].score}`);
+    }
+  });
+
+  it("without AffinityConfig, falls back to priority-first (backward compat)", () => {
+    const peerSkills = new Map([["Expert", ["deep-code"]]]);
+    // No affinityConfig → should behave like current matchRule: priority order, first match
+    const results = matchAllRules(rules, { text: "review code" }, peerSkills);
+    assert.ok(results.length > 0);
+    // "generalist" has higher priority (10 > 5), should be first
+    assert.equal(results[0].peer, "General");
+  });
+
+  it("returns empty array when no rules match", () => {
+    const noMatchRules = parseRoutingRules([
+      { name: "nope", match: { pattern: "^impossible$" }, target: { peer: "Bot" } },
+    ]);
+    const results = matchAllRules(noMatchRules, { text: "hello" });
+    assert.equal(results.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchRule backward compatibility with Hill scoring
+// ---------------------------------------------------------------------------
+
+describe("matchRule — backward compatibility with Hill scoring", () => {
+  it("existing tests still pass: matchRule returns first priority match", () => {
+    const rules: RoutingRule[] = parseRoutingRules([
+      { name: "low", match: { pattern: "test" }, target: { peer: "LowBot" }, priority: 1 },
+      { name: "high", match: { pattern: "test" }, target: { peer: "HighBot" }, priority: 100 },
+    ]);
+    const result = matchRule(rules, { text: "this is a test" });
+    assert.deepEqual(result, { peer: "HighBot" });
+  });
+
+  it("matchRule still returns null when no match", () => {
+    assert.equal(matchRule([], { text: "hello" }), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Performance: 1000 rules < 50ms
+// ---------------------------------------------------------------------------
+
+describe("matchAllRules — performance", () => {
+  it("1000 rules scored in under 50ms", () => {
+    const rawRules = Array.from({ length: 1000 }, (_, i) => ({
+      name: `rule-${i}`,
+      match: { pattern: `keyword${i % 10}`, skills: [`skill${i % 5}`] },
+      target: { peer: `Peer-${i % 20}` },
+      priority: i,
+    }));
+    const rules = parseRoutingRules(rawRules);
+    const peerSkills = new Map(
+      Array.from({ length: 20 }, (_, i) => [`Peer-${i}`, [`skill${i % 5}`, `skill${(i + 1) % 5}`]]),
+    );
+    const config: AffinityConfig = { hillCoefficient: 2, kd: 0.5 };
+
+    const start = performance.now();
+    matchAllRules(rules, { text: "keyword3 test" }, peerSkills, undefined, config);
+    const elapsed = performance.now() - start;
+
+    assert.ok(elapsed < 50, `Took ${elapsed.toFixed(1)}ms, expected < 50ms`);
   });
 });


### PR DESCRIPTION
## Summary

- **Hill equation routing**: Replace binary first-match routing with [Hill equation](https://en.wikipedia.org/wiki/Hill_equation_(biochemistry)) (Hill, 1910) affinity scoring. When `AffinityConfig` is provided, rules are scored by weighted multi-dimensional affinity (skills match ratio, tag match ratio, pattern match, success rate) and ranked via `score = affinity^n / (Kd^n + affinity^n)`.
- **New exports**: `hillScore()`, `computeAffinity()`, `matchAllRules()`, `AffinityConfig`, `AffinityWeights`, `ScoredMatch`
- **Backward compatible**: `matchRule()` signature unchanged; without `AffinityConfig`, behavior is identical to legacy priority-first matching
- **+15 test cases** (58 total for routing-rules, 378 full suite) — Hill math correctness, boundary values, affinity computation, scored sorting, backward compat, performance (1000 rules < 50ms)

### Bio-inspired design

Part of the biomimetic communication initiative (Phase 1.1). Maps cell signaling ligand-receptor specificity to agent routing affinity:

| Biology | A2A Gateway |
|---------|-------------|
| Ligand concentration | Weighted affinity score |
| Hill coefficient n | Routing steepness (n=1 linear, n>1 threshold) |
| Dissociation constant Kd | Half-saturation ("good enough" threshold) |
| Receptor specificity | Multi-dimensional skill/tag/pattern matching |

References: Hill (1910) J Physiol 40; Finlay et al. (2020) Br J Pharmacol 177(7):1472-1484.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `node --import tsx --test tests/routing-rules.test.ts` — 58/58 pass
- [x] `node --import tsx --test tests/*.test.ts` — 378/378 pass (zero regression)
- [x] Acceptance: `hillScore(0.5, 1, 0.5) === 0.5`, `hillScore(0.8, 3, 0.5) > hillScore(0.8, 1, 0.5)`
- [ ] `/a2a-pr-test` four-stage gate
- [ ] `/openclaw-explorer` live smoke test

🧬 Generated with [Claude Code](https://claude.com/claude-code)