### PR TITLE
feat: Michaelis-Menten soft concurrency limiting (Phase 2.3)

### DIFF
--- a/src/saturation-model.ts
+++ b/src/saturation-model.ts
@@ -1,0 +1,143 @@
+/**
+ * Michaelis-Menten saturation model for soft concurrency limiting.
+ *
+ * Enzyme kinetics: v = Vmax · [S] / (Km + [S])
+ *
+ * Instead of hard-rejecting tasks above a threshold, this model adds a
+ * progressive delay that increases with load, allowing the system to
+ * degrade gracefully.  Analogous to enzyme saturation: at Vmax the
+ * enzyme doesn't "reject" substrates — it processes them more slowly.
+ *
+ *   delay(load) = baseDelay · load / (Km + load)
+ *
+ * where:
+ *   - load = activeTasks / maxConcurrentTasks  (utilization ratio)
+ *   - Km   = load at which delay = baseDelay / 2  (half-saturation)
+ *   - baseDelay = maximum delay at full saturation
+ *
+ * At low load (load << Km): delay ≈ 0          (linear region)
+ * At Km:                    delay = baseDelay/2 (half-saturation)
+ * At high load (load >> Km): delay → baseDelay  (saturated plateau)
+ *
+ * The hard limit (maxConcurrentTasks) still applies — the saturation
+ * delay is purely additive, providing a soft "pressure" zone before the
+ * hard wall.
+ *
+ * @see Michaelis, L. & Menten, M.L. (1913) "Die Kinetik der
+ *   Invertinwirkung." Biochem Z 49:333-369.
+ * @see Johnson, K.A. & Goody, R.S. (2011) "The Original Michaelis
+ *   Constant." Biochemistry 50(39):8264-8269.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for Michaelis-Menten soft concurrency limiting.
+ *
+ * When provided to the queueing executor, a progressive delay is added
+ * before task execution based on the current load ratio.
+ */
+export interface SaturationConfig {
+  /**
+   * Half-saturation constant (as load ratio).  When utilization reaches
+   * this fraction of maxConcurrentTasks, delay equals baseDelayMs / 2.
+   *
+   * Lower Km → delay ramps up sooner (enzyme with high substrate affinity).
+   * Higher Km → delay ramps up later (enzyme with low affinity).
+   * @default 0.5
+   */
+  km?: number;
+  /**
+   * Maximum delay in ms at full saturation.
+   * @default 1000
+   */
+  baseDelayMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_KM = 0.5;
+const DEFAULT_BASE_DELAY_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Michaelis-Menten delay function.
+ *
+ *   delay = baseDelay × load / (Km + load)
+ *
+ * @param load       Current utilization ratio (activeTasks / maxConcurrent).
+ * @param km         Half-saturation constant.
+ * @param baseDelay  Maximum delay at saturation (ms).
+ * @returns Delay in ms, in range [0, baseDelay).
+ *
+ * @see Michaelis & Menten (1913) Biochem Z 49:333-369.
+ */
+export function michaelisMentenDelay(
+  load: number,
+  km: number,
+  baseDelay: number,
+): number {
+  if (load <= 0) return 0;
+  if (km <= 0) return baseDelay; // infinite affinity → instant saturation
+  return baseDelay * load / (km + load);
+}
+
+/**
+ * Compute the saturation delay for the current executor state.
+ *
+ * Convenience wrapper that converts raw task counts into a load ratio
+ * and applies the Michaelis-Menten model.
+ *
+ * @param activeTasks    Number of currently executing tasks.
+ * @param maxConcurrent  Hard concurrency limit.
+ * @param config         Saturation parameters (optional fields use defaults).
+ * @returns Delay in ms to apply before the next task starts.
+ */
+export function computeSaturationDelay(
+  activeTasks: number,
+  maxConcurrent: number,
+  config?: SaturationConfig,
+): number {
+  if (maxConcurrent <= 0 || activeTasks <= 0) return 0;
+  const load = activeTasks / maxConcurrent;
+  const km = config?.km ?? DEFAULT_KM;
+  const baseDelay = config?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  return michaelisMentenDelay(load, km, baseDelay);
+}
+
+// ---------------------------------------------------------------------------
+// Config parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse saturation config from raw user-provided config object.
+ * Returns `null` if saturation is not configured.
+ */
+export function parseSaturationConfig(
+  raw: Record<string, unknown> | undefined,
+): SaturationConfig | null {
+  if (!raw) return null;
+
+  const km =
+    typeof raw.km === "number" &&
+    Number.isFinite(raw.km) &&
+    raw.km > 0
+      ? raw.km
+      : DEFAULT_KM;
+
+  const baseDelayMs =
+    typeof raw.baseDelayMs === "number" &&
+    Number.isFinite(raw.baseDelayMs) &&
+    raw.baseDelayMs > 0
+      ? raw.baseDelayMs
+      : DEFAULT_BASE_DELAY_MS;
+
+  return { km, baseDelayMs };
+}

--- a/tests/saturation-model.test.ts
+++ b/tests/saturation-model.test.ts
@@ -1,0 +1,134 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  michaelisMentenDelay,
+  computeSaturationDelay,
+  parseSaturationConfig,
+} from "../src/saturation-model.js";
+
+// ---------------------------------------------------------------------------
+// michaelisMentenDelay — pure math
+// ---------------------------------------------------------------------------
+
+describe("michaelisMentenDelay", () => {
+  it("returns 0 when load is 0", () => {
+    assert.equal(michaelisMentenDelay(0, 0.5, 1000), 0);
+  });
+
+  it("returns 0 when load is negative", () => {
+    assert.equal(michaelisMentenDelay(-1, 0.5, 1000), 0);
+  });
+
+  it("returns half baseDelay when load equals Km", () => {
+    // At Km: delay = baseDelay * Km / (Km + Km) = baseDelay / 2
+    const delay = michaelisMentenDelay(0.5, 0.5, 1000);
+    assert.equal(delay, 500);
+  });
+
+  it("approaches baseDelay at very high load", () => {
+    // load=100, Km=0.5: delay = 1000 * 100 / (0.5 + 100) ≈ 995
+    const delay = michaelisMentenDelay(100, 0.5, 1000);
+    assert.ok(delay > 990);
+    assert.ok(delay < 1000);
+  });
+
+  it("is near 0 at very low load", () => {
+    // load=0.01, Km=0.5: delay = 1000 * 0.01 / (0.5 + 0.01) ≈ 19.6
+    const delay = michaelisMentenDelay(0.01, 0.5, 1000);
+    assert.ok(delay < 30);
+  });
+
+  it("returns baseDelay when Km is 0 (infinite affinity)", () => {
+    assert.equal(michaelisMentenDelay(0.5, 0, 1000), 1000);
+  });
+
+  it("is monotonically increasing with load", () => {
+    const delays = [0.1, 0.3, 0.5, 0.7, 1.0, 2.0].map(
+      (load) => michaelisMentenDelay(load, 0.5, 1000),
+    );
+    for (let i = 1; i < delays.length; i++) {
+      assert.ok(delays[i] > delays[i - 1], `delay at ${i} should be > delay at ${i - 1}`);
+    }
+  });
+
+  it("higher Km delays the onset of saturation", () => {
+    // At load=0.5: Km=0.3 gives higher delay than Km=0.8
+    const delayLowKm = michaelisMentenDelay(0.5, 0.3, 1000);
+    const delayHighKm = michaelisMentenDelay(0.5, 0.8, 1000);
+    assert.ok(delayLowKm > delayHighKm);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSaturationDelay — convenience wrapper
+// ---------------------------------------------------------------------------
+
+describe("computeSaturationDelay", () => {
+  it("returns 0 when no active tasks", () => {
+    assert.equal(computeSaturationDelay(0, 10), 0);
+  });
+
+  it("returns 0 when maxConcurrent is 0", () => {
+    assert.equal(computeSaturationDelay(5, 0), 0);
+  });
+
+  it("uses default config when none provided", () => {
+    // 5 active / 10 max = load 0.5, default Km=0.5, baseDelay=1000
+    // delay = 1000 * 0.5 / (0.5 + 0.5) = 500
+    const delay = computeSaturationDelay(5, 10);
+    assert.equal(delay, 500);
+  });
+
+  it("respects custom config", () => {
+    // 8 active / 10 max = load 0.8, Km=0.3, baseDelay=2000
+    // delay = 2000 * 0.8 / (0.3 + 0.8) ≈ 1454.5
+    const delay = computeSaturationDelay(8, 10, { km: 0.3, baseDelayMs: 2000 });
+    assert.ok(Math.abs(delay - 2000 * 0.8 / 1.1) < 1);
+  });
+
+  it("delay increases as load approaches max", () => {
+    const delays = [1, 3, 5, 7, 9].map(
+      (active) => computeSaturationDelay(active, 10, { km: 0.5, baseDelayMs: 1000 }),
+    );
+    for (let i = 1; i < delays.length; i++) {
+      assert.ok(delays[i] > delays[i - 1]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSaturationConfig
+// ---------------------------------------------------------------------------
+
+describe("parseSaturationConfig", () => {
+  it("returns null when raw is undefined", () => {
+    assert.equal(parseSaturationConfig(undefined), null);
+  });
+
+  it("parses valid config", () => {
+    const config = parseSaturationConfig({ km: 0.3, baseDelayMs: 2000 });
+    assert.ok(config);
+    assert.equal(config.km, 0.3);
+    assert.equal(config.baseDelayMs, 2000);
+  });
+
+  it("uses defaults for missing fields", () => {
+    const config = parseSaturationConfig({});
+    assert.ok(config);
+    assert.equal(config.km, 0.5);
+    assert.equal(config.baseDelayMs, 1000);
+  });
+
+  it("rejects non-positive km", () => {
+    const config = parseSaturationConfig({ km: -1 });
+    assert.ok(config);
+    assert.equal(config.km, 0.5); // falls back to default
+  });
+
+  it("rejects non-positive baseDelayMs", () => {
+    const config = parseSaturationConfig({ baseDelayMs: 0 });
+    assert.ok(config);
+    assert.equal(config.baseDelayMs, 1000); // falls back to default
+  });
+});


### PR DESCRIPTION
## Summary

Bio-inspired progressive concurrency delay modeled after enzyme kinetics (Michaelis-Menten).

- **`michaelisMentenDelay(load, km, baseDelay)`**: pure math function — delay grows hyperbolically with load
- **`computeSaturationDelay(active, max, config)`**: convenience wrapper converting task counts to delay
- **`parseSaturationConfig()`**: config parser with validation
- Fully backward-compatible: without `SaturationConfig`, no delay is applied

### Biology mapping

| Enzyme kinetics concept | A2A implementation |
|---|---|
| Substrate concentration [S] | `load = activeTasks / maxConcurrent` |
| Michaelis constant Km | Load ratio at half-maximal delay |
| Maximum velocity Vmax | `baseDelayMs` (saturation plateau) |
| Enzyme saturation curve | Progressive delay before hard rejection |

**Key property**: at load = Km, delay = baseDelay/2 (half-saturation, by definition).

### Delay curve at default settings (Km=0.5, baseDelay=1000ms)

| Load ratio | Delay (ms) |
|---|---|
| 0.1 | 167 |
| 0.3 | 375 |
| 0.5 | 500 |
| 0.7 | 583 |
| 0.9 | 643 |

**References**: Michaelis & Menten (1913) Biochem Z 49:333-369; Johnson & Goody (2011) Biochemistry 50(39):8264-8269.

## Test plan

- [x] 18 new tests: math correctness, half-saturation, monotonicity, boundary values, config parsing
- [x] `npx tsc --noEmit` zero errors
- [x] Zero regression on existing test suite
- [ ] `/a2a-pr-test` four-stage PR test
- [ ] `/openclaw-explorer` real bot probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)