### PR TITLE
feat(cli): improve developer experience for A2A CLI tools

### DIFF
--- a/skill/scripts/a2a-peers.mjs
+++ b/skill/scripts/a2a-peers.mjs
@@ -1,0 +1,75 @@
+/**
+ * Shared peer alias resolution for A2A CLI scripts.
+ *
+ * Reads ~/.openclaw/a2a-peers.json to resolve peer names to URLs and tokens.
+ *
+ * Config format (~/.openclaw/a2a-peers.json):
+ *   {
+ *     "AntiBot": { "url": "http://100.76.43.74:18800", "token": "abc123" },
+ *     "RuiZhi":  { "url": "http://100.76.43.75:18800", "token": "def456" },
+ *     "Legacy":  "http://192.168.1.100:18800"
+ *   }
+ *
+ * Values can be either an object { url, token? } or a plain URL string.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const PEERS_FILE = join(homedir(), ".openclaw", "a2a-peers.json");
+
+export function loadPeers() {
+  try {
+    return JSON.parse(readFileSync(PEERS_FILE, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve a peer name to { url, token }.
+ * Exits with error if name is not found.
+ */
+export function resolvePeer(name) {
+  const peers = loadPeers();
+  const entry = peers[name];
+  if (!entry) {
+    const available = Object.keys(peers);
+    console.error(`Unknown peer "${name}".`);
+    if (available.length > 0) {
+      console.error(`Available peers: ${available.join(", ")}`);
+    } else {
+      console.error(`No peers configured. Create ${PEERS_FILE} with:`);
+      console.error(`  { "AntiBot": { "url": "http://...", "token": "..." } }`);
+    }
+    process.exit(1);
+  }
+  return {
+    url: typeof entry === "string" ? entry : entry.url,
+    token: typeof entry === "object" ? (entry.token || "") : "",
+  };
+}
+
+/**
+ * Resolve peer URL and token from CLI opts, supporting --peer alias,
+ * --peer-url direct, and environment variable fallbacks.
+ *
+ * @param {object} opts - Parsed CLI options
+ * @returns {{ url: string, token: string }}
+ */
+export function resolveConnection(opts) {
+  if (opts.peer) {
+    const resolved = resolvePeer(String(opts.peer));
+    return {
+      url: resolved.url,
+      token: typeof opts.token === "string" ? opts.token : (resolved.token || process.env.A2A_TOKEN || ""),
+    };
+  }
+  return {
+    url: String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim(),
+    token: typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || ""),
+  };
+}
+
+export { PEERS_FILE };

--- a/skill/scripts/a2a-peers.mjs
+++ b/skill/scripts/a2a-peers.mjs
@@ -20,10 +20,18 @@ import { homedir } from "node:os";
 const PEERS_FILE = join(homedir(), ".openclaw", "a2a-peers.json");
 
 export function loadPeers() {
+  let raw;
   try {
-    return JSON.parse(readFileSync(PEERS_FILE, "utf-8"));
+    raw = readFileSync(PEERS_FILE, "utf-8");
   } catch {
-    return {};
+    return {};  // File doesn't exist — that's fine
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`Error parsing ${PEERS_FILE}: ${err.message}`);
+    console.error(`Fix the JSON syntax and retry.`);
+    process.exit(1);
   }
 }
 

--- a/skill/scripts/a2a-ping.mjs
+++ b/skill/scripts/a2a-ping.mjs
@@ -16,33 +16,7 @@
  *   --help                  Show this help text
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { homedir } from "node:os";
-
-const PEERS_FILE = join(homedir(), ".openclaw", "a2a-peers.json");
-
-function loadPeers() {
-  try {
-    return JSON.parse(readFileSync(PEERS_FILE, "utf-8"));
-  } catch {
-    return {};
-  }
-}
-
-function resolvePeer(name) {
-  const peers = loadPeers();
-  const entry = peers[name];
-  if (!entry) {
-    console.error(`Unknown peer "${name}". Available: ${Object.keys(peers).join(", ") || "(none)"}`);
-    console.error(`Configure peers in ${PEERS_FILE}`);
-    process.exit(1);
-  }
-  return {
-    url: typeof entry === "string" ? entry : entry.url,
-    token: typeof entry === "object" ? entry.token : undefined,
-  };
-}
+import { loadPeers, resolvePeer, resolveConnection, PEERS_FILE } from "./a2a-peers.mjs";
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -152,24 +126,16 @@ async function main() {
   }
 
   // Single peer mode
-  let url, token;
-
-  if (opts.peer) {
-    const resolved = resolvePeer(opts.peer);
-    url = resolved.url;
-    token = resolved.token || opts.token || process.env.A2A_TOKEN || "";
-  } else {
-    url = String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim();
-    token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
-  }
+  const { url, token } = resolveConnection(opts);
 
   if (!url) {
     console.error("Error: --peer-url, --peer <name>, or A2A_PEER_URL required");
     process.exit(1);
   }
 
+  const label = opts.peer || url;
   const result = await pingPeer(url, token, timeoutMs);
-  console.log(formatResult(url, result));
+  console.log(formatResult(label, result));
   process.exit(result.online ? 0 : 1);
 }
 

--- a/skill/scripts/a2a-ping.mjs
+++ b/skill/scripts/a2a-ping.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Check if an A2A peer is online by fetching its Agent Card.
+ *
+ * Usage:
+ *   node a2a-ping.mjs --peer-url <URL>
+ *   node a2a-ping.mjs --peer AntiBot               # resolve from ~/.openclaw/a2a-peers.json
+ *   node a2a-ping.mjs --all                         # ping all configured peers
+ *
+ * Options:
+ *   --peer-url <url>        Peer base URL (env: A2A_PEER_URL)
+ *   --peer <name>           Peer alias from ~/.openclaw/a2a-peers.json
+ *   --token <token>         Bearer token (env: A2A_TOKEN)
+ *   --all                   Ping all peers in ~/.openclaw/a2a-peers.json
+ *   --timeout-ms <ms>       Request timeout (default: 5000)
+ *   --help                  Show this help text
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const PEERS_FILE = join(homedir(), ".openclaw", "a2a-peers.json");
+
+function loadPeers() {
+  try {
+    return JSON.parse(readFileSync(PEERS_FILE, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function resolvePeer(name) {
+  const peers = loadPeers();
+  const entry = peers[name];
+  if (!entry) {
+    console.error(`Unknown peer "${name}". Available: ${Object.keys(peers).join(", ") || "(none)"}`);
+    console.error(`Configure peers in ${PEERS_FILE}`);
+    process.exit(1);
+  }
+  return {
+    url: typeof entry === "string" ? entry : entry.url,
+    token: typeof entry === "object" ? entry.token : undefined,
+  };
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg?.startsWith("--")) continue;
+    const key = arg.replace(/^--/, "");
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      opts[key] = next;
+      i++;
+    } else {
+      opts[key] = true;
+    }
+  }
+  return opts;
+}
+
+async function pingPeer(url, token, timeoutMs) {
+  const cardUrl = url.replace(/\/+$/, "") + "/.well-known/agent-card.json";
+  const headers = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+
+  const start = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(cardUrl, { headers, signal: controller.signal });
+    const latency = Date.now() - start;
+
+    if (!res.ok) {
+      return { online: false, latency, error: `HTTP ${res.status}` };
+    }
+
+    const card = await res.json();
+    return {
+      online: true,
+      latency,
+      name: card.name || card.agentName || "(unnamed)",
+      description: card.description || "",
+      version: card.version || "",
+    };
+  } catch (err) {
+    const latency = Date.now() - start;
+    if (err.name === "AbortError") {
+      return { online: false, latency, error: `timeout (${timeoutMs}ms)` };
+    }
+    const code = err?.cause?.code || "";
+    if (code === "ECONNREFUSED") {
+      return { online: false, latency, error: "connection refused" };
+    }
+    return { online: false, latency, error: err.message || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function formatResult(label, result) {
+  if (result.online) {
+    const parts = [`\u2705 ${label} — online (${result.latency}ms)`];
+    if (result.name) parts[0] += ` — ${result.name}`;
+    if (result.version) parts.push(`  version: ${result.version}`);
+    return parts.join("\n");
+  }
+  return `\u274C ${label} — offline (${result.error})`;
+}
+
+async function main() {
+  const opts = parseArgs();
+
+  if (opts.help || opts.h) {
+    console.log(`Usage: node a2a-ping.mjs [--peer-url <URL>] [--peer <name>] [--all] [--timeout-ms <ms>]`);
+    process.exit(0);
+  }
+
+  const timeoutMs = Number(opts["timeout-ms"] || opts.timeoutMs) || 5000;
+
+  // --all mode: ping every configured peer
+  if (opts.all) {
+    const peers = loadPeers();
+    const names = Object.keys(peers);
+    if (names.length === 0) {
+      console.error(`No peers configured. Create ${PEERS_FILE} with:`);
+      console.error(`  { "AntiBot": { "url": "http://...", "token": "..." } }`);
+      process.exit(1);
+    }
+
+    const results = await Promise.all(
+      names.map(async (name) => {
+        const entry = peers[name];
+        const url = typeof entry === "string" ? entry : entry.url;
+        const token = typeof entry === "object" ? entry.token : undefined;
+        const result = await pingPeer(url, token, timeoutMs);
+        return { name, result };
+      })
+    );
+
+    for (const { name, result } of results) {
+      console.log(formatResult(name, result));
+    }
+
+    const onlineCount = results.filter((r) => r.result.online).length;
+    console.log(`\n${onlineCount}/${results.length} peers online`);
+    process.exit(onlineCount === results.length ? 0 : 1);
+  }
+
+  // Single peer mode
+  let url, token;
+
+  if (opts.peer) {
+    const resolved = resolvePeer(opts.peer);
+    url = resolved.url;
+    token = resolved.token || opts.token || process.env.A2A_TOKEN || "";
+  } else {
+    url = String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim();
+    token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
+  }
+
+  if (!url) {
+    console.error("Error: --peer-url, --peer <name>, or A2A_PEER_URL required");
+    process.exit(1);
+  }
+
+  const result = await pingPeer(url, token, timeoutMs);
+  console.log(formatResult(url, result));
+  process.exit(result.online ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Error:", err.message || String(err));
+  process.exit(1);
+});

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -355,6 +355,7 @@ async function main() {
 
   const startedAt = Date.now();
   const terminalStates = new Set(["completed", "failed", "canceled", "rejected"]);
+  const blockedStates = new Set(["input-required", "auth-required"]);
 
   while (true) {
     const task = await client.getTask({ id: responseTaskId, historyLength: 20 }, requestOptions);
@@ -364,6 +365,13 @@ async function main() {
       const text = extractFirstTextParts(task.status?.message?.parts);
       console.log(text || JSON.stringify(task, null, 2));
       return;
+    }
+
+    if (state && blockedStates.has(state)) {
+      console.error(`\nTask is blocked (${state}). It needs external action to proceed.`);
+      console.error(`Check status later: node a2a-status.mjs --task-id ${responseTaskId}`);
+      console.log(JSON.stringify(task, null, 2));
+      process.exit(2);
     }
 
     if (Date.now() - startedAt > timeoutMs) {

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -113,8 +113,8 @@ function parseArgs() {
   const fileUri = String(opts["file-uri"] || opts.fileUri || "").trim();
   const filePath = String(opts["file-path"] || opts.filePath || "").trim();
 
-  // At least one of --message, --file-uri, --file-path required
-  if (!peerUrl || (!message && !fileUri && !filePath)) {
+  // Need a peer target (--peer-url, --peer alias, or A2A_PEER_URL) and at least one payload
+  if ((!peerUrl && !opts.peer) || (!message && !fileUri && !filePath)) {
     usageAndExit(1);
   }
 
@@ -282,6 +282,8 @@ async function main() {
   // SSE streaming mode: subscribe to task event stream
   if (stream) {
     console.log("[stream] connecting...");
+    // Note: stream mode does not auto-retry — connection errors surface immediately.
+    // Retrying a partially-consumed stream has different semantics than retrying a single RPC.
     const eventStream = client.sendMessageStream(sendParams, requestOptions);
     for await (const event of eventStream) {
       const kind = event?.kind;
@@ -352,7 +354,7 @@ async function main() {
   }
 
   const startedAt = Date.now();
-  const terminalStates = new Set(["completed", "failed", "canceled"]);
+  const terminalStates = new Set(["completed", "failed", "canceled", "rejected"]);
 
   while (true) {
     const task = await client.getTask({ id: responseTaskId, historyLength: 20 }, requestOptions);
@@ -398,7 +400,7 @@ main().catch((err) => {
 
   if (code === "ENOTFOUND" || msg.includes("ENOTFOUND")) {
     console.error(`DNS lookup failed — hostname not found.`);
-    console.error(`  Check the peer URL for typos: ${process.env.A2A_PEER_URL || "(not set)"}`);
+    console.error(`  Check the peer URL for typos (--peer-url or A2A_PEER_URL).`);
     process.exit(1);
   }
 

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -11,8 +11,8 @@
  *   node a2a-send.mjs --peer-url <URL> --token <TOKEN> --non-blocking --wait --message "..."
  *
  * Options:
- *   --peer-url <url>        Peer base URL, e.g. http://100.76.43.74:18800
- *   --token <token>         Bearer token for the peer inbound auth
+ *   --peer-url <url>        Peer base URL, e.g. http://100.76.43.74:18800 (env: A2A_PEER_URL)
+ *   --token <token>         Bearer token for the peer inbound auth (env: A2A_TOKEN)
  *   --message <text>        Text to send
  *   --task-id <id>          Reuse an existing A2A task for follow-up turns
  *   --context-id <id>       Reuse an existing A2A context for multi-round conversation routing
@@ -106,7 +106,7 @@ function parseArgs() {
     usageAndExit(0);
   }
 
-  const peerUrl = String(opts["peer-url"] || opts.peerUrl || "").trim();
+  const peerUrl = String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim();
   const message = String(opts.message || "").trim();
   const fileUri = String(opts["file-uri"] || opts.fileUri || "").trim();
   const filePath = String(opts["file-path"] || opts.filePath || "").trim();
@@ -137,7 +137,7 @@ async function main() {
   const opts = parseArgs();
 
   const peerUrl = opts.peerUrl;
-  const token = typeof opts.token === "string" ? opts.token : "";
+  const token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
   const message = opts.message;
   const targetAgentId = (opts["agent-id"] || opts.agentId || "").toString().trim();
   const continuationTaskId = (opts["task-id"] || opts.taskId || "").toString().trim().slice(0, 256);

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -123,6 +123,28 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const RETRYABLE_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "ENOTFOUND", "UND_ERR_CONNECT_TIMEOUT", "EPIPE"]);
+
+function isRetryableError(err) {
+  const code = err?.cause?.code || err?.code || "";
+  if (RETRYABLE_CODES.has(code)) return true;
+  const msg = err?.message || "";
+  return RETRYABLE_CODES.has(msg) || msg.includes("fetch failed") || msg.includes("ECONNREFUSED");
+}
+
+async function retryOnConnectionError(fn, { maxRetries = 3, baseDelayMs = 2000 } = {}) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= maxRetries || !isRetryableError(err)) throw err;
+      const delay = baseDelayMs * Math.pow(2, attempt);
+      console.error(`Connection failed (${err?.cause?.code || err?.message}), retrying in ${(delay / 1000).toFixed(0)}s... (${attempt + 1}/${maxRetries})`);
+      await sleep(delay);
+    }
+  }
+}
+
 function extractFirstTextParts(parts) {
   if (!Array.isArray(parts)) return undefined;
   for (const p of parts) {
@@ -195,8 +217,8 @@ async function main() {
     })
   );
 
-  // Discover agent card and create client
-  const client = await factory.createFromUrl(peerUrl);
+  // Discover agent card and create client (with retry for transient network errors)
+  const client = await retryOnConnectionError(() => factory.createFromUrl(peerUrl));
 
   // Build message parts: text + optional file
   const outboundParts = [];
@@ -284,7 +306,7 @@ async function main() {
     return;
   }
 
-  const result = await client.sendMessage(sendParams, requestOptions);
+  const result = await retryOnConnectionError(() => client.sendMessage(sendParams, requestOptions));
 
   const printTaskHandle = (task) => {
     if (!task || typeof task !== "object") return;

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -364,7 +364,11 @@ async function main() {
     }
 
     if (Date.now() - startedAt > timeoutMs) {
-      console.error(`Timeout waiting for task ${responseTaskId} after ${timeoutMs}ms`);
+      const elapsed = (timeoutMs / 1000).toFixed(0);
+      const lastState = task?.status?.state || "unknown";
+      console.error(`\nTimeout: task ${responseTaskId} still "${lastState}" after ${elapsed}s`);
+      console.error(`Tip: increase --timeout-ms or check status later with:`);
+      console.error(`  node a2a-status.mjs --task-id ${responseTaskId} --wait`);
       console.log(JSON.stringify(task, null, 2));
       process.exit(3);
     }
@@ -374,6 +378,35 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("Error:", err?.stack || err?.message || String(err));
+  const msg = err?.message || String(err);
+  const code = err?.cause?.code || err?.code || "";
+
+  if (code === "ECONNREFUSED" || msg.includes("ECONNREFUSED")) {
+    console.error(`Connection refused — peer is not reachable.`);
+    console.error(`  1. Check if the peer is running: curl -s <peer-url>/.well-known/agent-card.json`);
+    console.error(`  2. Verify the URL: --peer-url or A2A_PEER_URL`);
+    console.error(`  3. Check network/firewall (Tailscale connected?)`);
+    process.exit(1);
+  }
+
+  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT" || msg.includes("ETIMEDOUT")) {
+    console.error(`Connection timed out — peer is not responding.`);
+    console.error(`  Network path may be blocked or peer is overloaded.`);
+    process.exit(1);
+  }
+
+  if (code === "ENOTFOUND" || msg.includes("ENOTFOUND")) {
+    console.error(`DNS lookup failed — hostname not found.`);
+    console.error(`  Check the peer URL for typos: ${process.env.A2A_PEER_URL || "(not set)"}`);
+    process.exit(1);
+  }
+
+  if (msg.includes("401") || msg.includes("Unauthorized")) {
+    console.error(`Authentication failed (401) — token is invalid or expired.`);
+    console.error(`  Update --token or A2A_TOKEN env var.`);
+    process.exit(1);
+  }
+
+  console.error("Error:", err?.stack || msg);
   process.exit(1);
 });

--- a/skill/scripts/a2a-send.mjs
+++ b/skill/scripts/a2a-send.mjs
@@ -3,14 +3,15 @@
  * Send a message to an A2A peer using the official @a2a-js/sdk.
  *
  * Usage:
- *   node a2a-send.mjs --peer-url <PEER_BASE_URL> --token <TOKEN> --message "Hello!"
+ *   node a2a-send.mjs --peer AntiBot --message "Hello!"
  *   node a2a-send.mjs --peer-url http://100.76.43.74:18800 --token abc123 --message "What is your name?"
- *   node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message "Follow up" --task-id <TASK_ID> --context-id <CONTEXT_ID>
+ *   node a2a-send.mjs --peer AntiBot --message "Follow up" --task-id <TASK_ID> --context-id <CONTEXT_ID>
  *
  * Async task mode (recommended for long-running prompts):
- *   node a2a-send.mjs --peer-url <URL> --token <TOKEN> --non-blocking --wait --message "..."
+ *   node a2a-send.mjs --peer AntiBot --non-blocking --wait --message "..."
  *
  * Options:
+ *   --peer <name>           Peer alias from ~/.openclaw/a2a-peers.json
  *   --peer-url <url>        Peer base URL, e.g. http://100.76.43.74:18800 (env: A2A_PEER_URL)
  *   --token <token>         Bearer token for the peer inbound auth (env: A2A_TOKEN)
  *   --message <text>        Text to send
@@ -42,8 +43,9 @@ import { GrpcTransportFactory } from "@a2a-js/sdk/client/grpc";
 import { randomUUID } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { extname } from "node:path";
+import { resolveConnection } from "./a2a-peers.mjs";
 
-const USAGE = `Usage: node a2a-send.mjs --peer-url <URL> --token <TOKEN> --message <TEXT> [--file-uri <url>] [--file-path <localpath>] [--task-id <id>] [--context-id <id>] [--non-blocking] [--wait] [--stream] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>] [--help]`;
+const USAGE = `Usage: node a2a-send.mjs [--peer <name> | --peer-url <URL>] --message <TEXT> [--file-uri <url>] [--file-path <localpath>] [--task-id <id>] [--context-id <id>] [--non-blocking] [--wait] [--stream] [--timeout-ms <ms>] [--poll-ms <ms>] [--agent-id <openclaw-agent-id>] [--help]`;
 
 const MAX_INLINE_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
@@ -158,8 +160,7 @@ function extractFirstTextParts(parts) {
 async function main() {
   const opts = parseArgs();
 
-  const peerUrl = opts.peerUrl;
-  const token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
+  const { url: peerUrl, token } = resolveConnection(opts);
   const message = opts.message;
   const targetAgentId = (opts["agent-id"] || opts.agentId || "").toString().trim();
   const continuationTaskId = (opts["task-id"] || opts.taskId || "").toString().trim().slice(0, 256);

--- a/skill/scripts/a2a-status.mjs
+++ b/skill/scripts/a2a-status.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Query the status of an A2A task by its task ID.
+ *
+ * Usage:
+ *   node a2a-status.mjs --task-id <TASK_ID>
+ *   node a2a-status.mjs --task-id <TASK_ID> --wait
+ *   node a2a-status.mjs --peer-url <URL> --token <TOKEN> --task-id <TASK_ID> --wait --timeout-ms 30000
+ *
+ * Options:
+ *   --peer-url <url>        Peer base URL (env: A2A_PEER_URL)
+ *   --token <token>         Bearer token (env: A2A_TOKEN)
+ *   --task-id <id>          Task ID to query (required)
+ *   --wait                  Poll until terminal state (completed/failed/canceled)
+ *   --timeout-ms <ms>       Max wait time (default: 600000)
+ *   --poll-ms <ms>          Poll interval (default: 2000)
+ *   --json                  Output raw JSON instead of formatted text
+ *   --help                  Show this help text
+ *
+ * Requires: npm install @a2a-js/sdk
+ */
+
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+  createAuthenticatingFetchWithRetry,
+} from "@a2a-js/sdk/client";
+import { GrpcTransportFactory } from "@a2a-js/sdk/client/grpc";
+
+const USAGE = `Usage: node a2a-status.mjs --task-id <TASK_ID> [--peer-url <URL>] [--token <TOKEN>] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--json] [--help]`;
+
+function usageAndExit(code = 1) {
+  const stream = code === 0 ? console.log : console.error;
+  stream(USAGE);
+  process.exit(code);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg?.startsWith("--")) continue;
+    const key = arg.replace(/^--/, "");
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) {
+      opts[key] = next;
+      i++;
+    } else {
+      opts[key] = true;
+    }
+  }
+  if (opts.help || opts.h) usageAndExit(0);
+  return opts;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function extractText(parts) {
+  if (!Array.isArray(parts)) return undefined;
+  for (const p of parts) {
+    if (p?.kind === "text" && typeof p.text === "string") return p.text;
+  }
+  return undefined;
+}
+
+const STATE_LABELS = {
+  submitted: "⏳ submitted (queued)",
+  working:   "⚙️  working",
+  completed: "✅ completed",
+  failed:    "❌ failed",
+  canceled:  "🚫 canceled",
+  rejected:  "🚫 rejected",
+};
+
+function formatTask(task) {
+  const state = task?.status?.state || "unknown";
+  const label = STATE_LABELS[state] || state;
+  const text = extractText(task?.status?.message?.parts);
+  const ts = task?.status?.timestamp || "";
+
+  let out = `[${label}] task=${task.id}`;
+  if (task.contextId) out += ` context=${task.contextId}`;
+  if (ts) out += ` (${ts})`;
+  if (text) out += `\n${text}`;
+  return out;
+}
+
+async function main() {
+  const opts = parseArgs();
+
+  const peerUrl = String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim();
+  const token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
+  const taskId = String(opts["task-id"] || opts.taskId || "").trim();
+  const wait = Boolean(opts.wait);
+  const json = Boolean(opts.json);
+
+  const timeoutMs = Number(opts["timeout-ms"] || opts.timeoutMs) || 600_000;
+  const pollMs = Number(opts["poll-ms"] || opts.pollMs) || 2_000;
+
+  if (!peerUrl) {
+    console.error("Error: --peer-url is required (or set A2A_PEER_URL env var)");
+    usageAndExit(1);
+  }
+  if (!taskId) {
+    console.error("Error: --task-id is required");
+    usageAndExit(1);
+  }
+
+  // Build client
+  const authHandler = token
+    ? {
+        headers: async () => ({ authorization: `Bearer ${token}` }),
+        shouldRetryWithHeaders: async () => undefined,
+      }
+    : undefined;
+
+  const authFetch = authHandler
+    ? createAuthenticatingFetchWithRetry(fetch, authHandler)
+    : fetch;
+
+  const factory = new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      cardResolver: new DefaultAgentCardResolver({ fetchImpl: authFetch }),
+      transports: [
+        new JsonRpcTransportFactory({ fetchImpl: authFetch }),
+        new RestTransportFactory({ fetchImpl: authFetch }),
+        new GrpcTransportFactory(),
+      ],
+    })
+  );
+
+  const client = await factory.createFromUrl(peerUrl);
+  const requestOptions = token ? { serviceParameters: { authorization: `Bearer ${token}` } } : undefined;
+  const terminalStates = new Set(["completed", "failed", "canceled", "rejected"]);
+
+  // Single query mode
+  if (!wait) {
+    const task = await client.getTask({ id: taskId, historyLength: 20 }, requestOptions);
+    if (json) {
+      console.log(JSON.stringify(task, null, 2));
+    } else {
+      console.log(formatTask(task));
+    }
+    return;
+  }
+
+  // Polling mode
+  const startedAt = Date.now();
+  let lastState = "";
+
+  while (true) {
+    const task = await client.getTask({ id: taskId, historyLength: 20 }, requestOptions);
+    const state = task?.status?.state;
+
+    // Print state transitions
+    if (state !== lastState) {
+      if (json) {
+        console.log(JSON.stringify({ state, timestamp: task?.status?.timestamp }));
+      } else {
+        console.log(formatTask(task));
+      }
+      lastState = state;
+    }
+
+    if (state && terminalStates.has(state)) return;
+
+    if (Date.now() - startedAt > timeoutMs) {
+      console.error(`\nTimeout: task ${taskId} still in "${state}" state after ${(timeoutMs / 1000).toFixed(0)}s`);
+      console.error(`Tip: re-run with a longer --timeout-ms, or query again later without --wait`);
+      process.exit(3);
+    }
+
+    await sleep(pollMs);
+  }
+}
+
+main().catch((err) => {
+  const msg = err?.message || String(err);
+
+  if (err?.cause?.code === "ECONNREFUSED" || msg.includes("ECONNREFUSED")) {
+    console.error(`Connection refused — is the peer online?`);
+    console.error(`  Check: curl -s <peer-url>/.well-known/agent-card.json`);
+    process.exit(1);
+  }
+
+  console.error("Error:", msg);
+  process.exit(1);
+});

--- a/skill/scripts/a2a-status.mjs
+++ b/skill/scripts/a2a-status.mjs
@@ -3,11 +3,12 @@
  * Query the status of an A2A task by its task ID.
  *
  * Usage:
- *   node a2a-status.mjs --task-id <TASK_ID>
+ *   node a2a-status.mjs --peer AntiBot --task-id <TASK_ID>
  *   node a2a-status.mjs --task-id <TASK_ID> --wait
  *   node a2a-status.mjs --peer-url <URL> --token <TOKEN> --task-id <TASK_ID> --wait --timeout-ms 30000
  *
  * Options:
+ *   --peer <name>           Peer alias from ~/.openclaw/a2a-peers.json
  *   --peer-url <url>        Peer base URL (env: A2A_PEER_URL)
  *   --token <token>         Bearer token (env: A2A_TOKEN)
  *   --task-id <id>          Task ID to query (required)
@@ -29,8 +30,9 @@ import {
   createAuthenticatingFetchWithRetry,
 } from "@a2a-js/sdk/client";
 import { GrpcTransportFactory } from "@a2a-js/sdk/client/grpc";
+import { resolveConnection } from "./a2a-peers.mjs";
 
-const USAGE = `Usage: node a2a-status.mjs --task-id <TASK_ID> [--peer-url <URL>] [--token <TOKEN>] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--json] [--help]`;
+const USAGE = `Usage: node a2a-status.mjs --task-id <TASK_ID> [--peer <name> | --peer-url <URL>] [--token <TOKEN>] [--wait] [--timeout-ms <ms>] [--poll-ms <ms>] [--json] [--help]`;
 
 function usageAndExit(code = 1) {
   const stream = code === 0 ? console.log : console.error;
@@ -94,8 +96,7 @@ function formatTask(task) {
 async function main() {
   const opts = parseArgs();
 
-  const peerUrl = String(opts["peer-url"] || opts.peerUrl || process.env.A2A_PEER_URL || "").trim();
-  const token = typeof opts.token === "string" ? opts.token : (process.env.A2A_TOKEN || "");
+  const { url: peerUrl, token } = resolveConnection(opts);
   const taskId = String(opts["task-id"] || opts.taskId || "").trim();
   const wait = Boolean(opts.wait);
   const json = Boolean(opts.json);

--- a/skill/scripts/a2a-status.mjs
+++ b/skill/scripts/a2a-status.mjs
@@ -139,6 +139,7 @@ async function main() {
   const client = await factory.createFromUrl(peerUrl);
   const requestOptions = token ? { serviceParameters: { authorization: `Bearer ${token}` } } : undefined;
   const terminalStates = new Set(["completed", "failed", "canceled", "rejected"]);
+  const blockedStates = new Set(["input-required", "auth-required"]);
 
   // Single query mode
   if (!wait) {
@@ -170,6 +171,11 @@ async function main() {
     }
 
     if (state && terminalStates.has(state)) return;
+
+    if (state && blockedStates.has(state)) {
+      console.error(`\nTask is blocked (${state}). It needs external action to proceed.`);
+      process.exit(2);
+    }
 
     if (Date.now() - startedAt > timeoutMs) {
       console.error(`\nTimeout: task ${taskId} still in "${state}" state after ${(timeoutMs / 1000).toFixed(0)}s`);


### PR DESCRIPTION
## Summary

Based on feedback from three agents (user, RuiZhi, AntiBot) after real-world A2A usage.

### CLI Developer Experience Improvements

- **Environment variables**: `A2A_PEER_URL` / `A2A_TOKEN` — no more typing `--peer-url` and `--token` every time
- **Peer aliases**: `--peer AntiBot` resolves URL+token from `~/.openclaw/a2a-peers.json`, shared across all scripts
- **`a2a-status.mjs`**: Query task state by ID, supports `--wait` polling — enables fire-and-forget workflows
- **`a2a-ping.mjs`**: Health check before sending — know if peer is online, supports `--all` to check every configured peer
- **Connection retry**: 3x exponential backoff (2/4/8s) on transient network errors (ECONNREFUSED, ETIMEDOUT)
- **Friendly errors**: Actionable diagnostics for connection refused, timeout, DNS failure, and auth errors
- **Shared module**: `a2a-peers.mjs` — common peer resolution logic used by all three scripts

### Usage Examples

```bash
# Configure peers once
cat > ~/.openclaw/a2a-peers.json << 'CONF'
{
  "AntiBot": { "url": "http://100.76.43.74:18800", "token": "abc123" },
  "RuiZhi":  { "url": "http://100.76.43.75:18800", "token": "def456" }
}
CONF

# Health check
node a2a-ping.mjs --all                              # check all peers
node a2a-ping.mjs --peer AntiBot                      # check one peer

# Send messages (was 6 params, now 2)
node a2a-send.mjs --peer AntiBot --message "Hello"

# Fire-and-forget + check later
node a2a-send.mjs --peer AntiBot --non-blocking --message "Review this article"
# → [task] id=abc-123
node a2a-status.mjs --peer AntiBot --task-id abc-123         # instant check
node a2a-status.mjs --peer AntiBot --task-id abc-123 --wait  # poll until done
```

## Test plan

- [x] `node --check` syntax validation for all 4 scripts
- [x] 475 existing tests pass (0 failures)
- [ ] Manual: configure `a2a-peers.json` and verify `--peer` alias resolution
- [ ] Manual: `a2a-ping.mjs --all` reports correct online/offline status
- [ ] Manual: `a2a-status.mjs --task-id <id>` returns task state
- [ ] Manual: peer offline → retry 3x with backoff → friendly error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)