### PR TITLE
fix: detect silent scope downgrade on cross-machine connect (#54)

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -604,14 +604,31 @@ class GatewayRpcConnection {
     }
 
     try {
-      await this.request("connect", this.buildConnectParams(true), GATEWAY_CONNECT_TIMEOUT_MS, false);
+      const connectResult = await this.request("connect", this.buildConnectParams(true), GATEWAY_CONNECT_TIMEOUT_MS, false);
+
+      // Verify scopes were preserved — OpenClaw ≥2026.3.13 may silently
+      // downgrade scopes when the device identity is not recognized (e.g.
+      // cross-machine setups where device.json belongs to a different host).
+      if (this.isOperatorWriteMissing(connectResult)) {
+        this.challengeNonce = "";
+        await this.reconnect();
+
+        // If token-only reconnect also lacks operator.write, surface a clear error
+        // so the user knows device pairing is required.
+        return;
+      }
     } catch (connectError: unknown) {
       const msg = connectError instanceof Error ? connectError.message : String(connectError);
       // On older gateways (≤2026.3.11), sending a device identity may trigger
       // "pairing required" if silent auto-pairing is not supported.
-      // Retry without device identity — the gateway token alone is sufficient
-      // on those versions because they preserve scopes for shared-auth connections.
-      if (msg.includes("pairing required") || msg.includes("device identity required")) {
+      // Also match variants introduced in later gateway versions.
+      if (
+        msg.includes("pairing required") ||
+        msg.includes("device identity required") ||
+        msg.includes("device not paired") ||
+        msg.includes("unknown device") ||
+        msg.includes("identity verification failed")
+      ) {
         this.challengeNonce = "";
         await this.reconnect();
         return;
@@ -664,7 +681,19 @@ class GatewayRpcConnection {
     });
 
     await challengePromise;
-    await this.request("connect", this.buildConnectParams(false), GATEWAY_CONNECT_TIMEOUT_MS, false);
+    const reconnectResult = await this.request("connect", this.buildConnectParams(false), GATEWAY_CONNECT_TIMEOUT_MS, false);
+
+    // If token-only auth also fails to preserve scopes, the gateway requires
+    // a paired device identity.  Surface a clear error so the operator knows
+    // what to do rather than getting a cryptic "missing scope" later.
+    if (this.isOperatorWriteMissing(reconnectResult)) {
+      throw new Error(
+        "Gateway connected but operator.write scope was not granted. "
+        + "On OpenClaw ≥2026.3.13, cross-machine connections require a paired "
+        + "device identity. Run 'openclaw pair' on the gateway host or copy "
+        + "~/.openclaw/identity/device.json from the gateway machine."
+      );
+    }
   }
 
   async request(
@@ -845,6 +874,21 @@ class GatewayRpcConnection {
     }
 
     return params;
+  }
+
+  /**
+   * Check whether the connect response indicates that operator.write was
+   * not granted.  Returns true only when the response explicitly lists
+   * granted scopes AND operator.write is absent — i.e. a silent downgrade.
+   * If the response does not contain scope information (older gateways)
+   * we conservatively return false (assume scopes are fine).
+   */
+  private isOperatorWriteMissing(connectResult: unknown): boolean {
+    const obj = asObject(connectResult);
+    if (!obj) return false;
+    const scopes = obj.scopes;
+    if (!Array.isArray(scopes)) return false;
+    return !scopes.includes("operator.write");
   }
 
   private handleMessage(event: { data: unknown }): void {

--- a/tests/a2a-gateway.test.ts
+++ b/tests/a2a-gateway.test.ts
@@ -839,3 +839,231 @@ describe("a2a-gateway plugin", () => {
     }
   });
 });
+
+describe("scope verification on connect (issue #54)", () => {
+  it("falls back to reconnect when scopes are silently downgraded", async () => {
+    const api = createApi();
+    let connectAttempts = 0;
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: (params) => {
+        connectAttempts++;
+        // First connect (with device identity): return downgraded scopes
+        if (connectAttempts === 1 && params.device) {
+          return { scopes: ["operator.read"] };
+        }
+        // Reconnect (without device): return full scopes
+        return { scopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals"] };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+      const published: unknown[] = [];
+
+      await executor.execute(
+        {
+          taskId: "task-scope-1",
+          contextId: "ctx-scope-1",
+          userMessage: {
+            messageId: "msg-scope-1",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test scope fallback" }],
+          },
+        } as any,
+        {
+          publish(event: unknown) { published.push(event); },
+          finished() {},
+        } as any,
+      );
+
+      // Should have connected twice: initial with device identity (downgraded),
+      // then reconnect without device identity (full scopes).
+      assert.ok(connectAttempts >= 2, `should have attempted at least 2 connects but got ${connectAttempts}`);
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("publishes failed task with clear error when both connect paths lack operator.write", async () => {
+    const api = createApi();
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: () => {
+        // Always return downgraded scopes — both paths fail
+        return { scopes: ["operator.read"] };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+      const published: unknown[] = [];
+
+      await executor.execute(
+        {
+          taskId: "task-scope-2",
+          contextId: "ctx-scope-2",
+          userMessage: {
+            messageId: "msg-scope-2",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test scope error" }],
+          },
+        } as any,
+        {
+          publish(event: unknown) { published.push(event); },
+          finished() {},
+        } as any,
+      );
+
+      // The executor catches dispatch errors and publishes a "failed" task.
+      // Find the failed task event and verify the error message is actionable.
+      const failedTask = published.find((e: any) => e.status?.state === "failed") as any;
+      assert.ok(failedTask, "should publish a failed task when scopes are downgraded");
+
+      const failedText = failedTask.status?.message?.parts?.[0]?.text ?? "";
+      assert.ok(
+        failedText.includes("operator.write") || failedText.includes("scope"),
+        `failed task message should mention scope issue but got: ${failedText}`,
+      );
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("widens fallback to catch 'device not paired' error text", async () => {
+    const api = createApi();
+    let reconnected = false;
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: (params) => {
+        if (params.device && !reconnected) {
+          reconnected = true;
+          throw new Error("device not paired");
+        }
+        // Reconnect without device: return full scopes
+        return { scopes: ["operator.admin", "operator.read", "operator.write"] };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+      const published: unknown[] = [];
+
+      await executor.execute(
+        {
+          taskId: "task-scope-3",
+          contextId: "ctx-scope-3",
+          userMessage: {
+            messageId: "msg-scope-3",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test device not paired" }],
+          },
+        } as any,
+        {
+          publish(event: unknown) { published.push(event); },
+          finished() {},
+        } as any,
+      );
+
+      assert.ok(reconnected, "should have triggered reconnect via 'device not paired' error");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("does not trigger fallback when scopes include operator.write", async () => {
+    const api = createApi();
+    let connectAttempts = 0;
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: () => {
+        connectAttempts++;
+        // Always return full scopes — no fallback needed
+        return { scopes: ["operator.admin", "operator.read", "operator.write"] };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+
+      await executor.execute(
+        {
+          taskId: "task-scope-4",
+          contextId: "ctx-scope-4",
+          userMessage: {
+            messageId: "msg-scope-4",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test no fallback" }],
+          },
+        } as any,
+        {
+          publish() {},
+          finished() {},
+        } as any,
+      );
+
+      // Should have connected only once — no reconnect needed
+      assert.equal(connectAttempts, 1, "should connect only once when scopes are fine");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("does not trigger fallback when response has no scopes field (older gateway)", async () => {
+    const api = createApi();
+    let connectAttempts = 0;
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: () => {
+        connectAttempts++;
+        // Older gateway: no scopes field in response
+        return { status: "ok" };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+
+    try {
+      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+
+      await executor.execute(
+        {
+          taskId: "task-scope-5",
+          contextId: "ctx-scope-5",
+          userMessage: {
+            messageId: "msg-scope-5",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test older gateway" }],
+          },
+        } as any,
+        {
+          publish() {},
+          finished() {},
+        } as any,
+      );
+
+      // Should have connected only once — conservatively assume scopes are fine
+      assert.equal(connectAttempts, 1, "should connect only once for older gateway without scopes");
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -84,6 +84,7 @@ export function createApi() {
 
 export function createMockWebSocketClass(options?: {
   onAgent?: (params: Record<string, unknown>) => void;
+  onConnect?: (params: Record<string, unknown>) => Record<string, unknown>;
   agentResponseText?: string;
   agentResponsePayloads?: Array<Record<string, unknown>>;
 }) {
@@ -117,7 +118,17 @@ export function createMockWebSocketClass(options?: {
     send(data: string): void {
       const frame = JSON.parse(data) as { id: string; method: string; params?: any };
       if (frame.method === "connect") {
-        this.respond(frame.id, true, { status: "ok" });
+        if (options?.onConnect) {
+          try {
+            const result = options.onConnect(frame.params || {});
+            this.respond(frame.id, true, result);
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.respond(frame.id, false, null, { message: msg });
+          }
+        } else {
+          this.respond(frame.id, true, { status: "ok" });
+        }
         return;
       }
       if (frame.method === "sessions.resolve") {


### PR DESCRIPTION
## Summary
- Verifies granted scopes after WebSocket connect — detects silent `operator.write` downgrade on OpenClaw ≥2026.3.13 (cross-machine device identity mismatch)
- Widens fallback error matching to handle additional device identity rejection messages from newer gateway versions ("device not paired", "unknown device", "identity verification failed")
- Falls back to token-only reconnect on scope downgrade; if that also fails, throws a clear diagnostic error with remediation steps (`openclaw pair` or copy `device.json`)
- Adds `isOperatorWriteMissing()` helper for DRY scope verification
- 5 new tests covering: scope downgrade fallback, both-paths-fail error, widened error matching, no-fallback when scopes OK, backward compat with older gateways

Closes #54

## Test plan
- [x] All 491 tests pass (`npm test`) — 0 failures
- [ ] Manual test: two-machine A2A setup with mismatched device.json → should get clear error instead of cryptic "missing scope"
- [ ] openclaw-explorer E2E validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)