### PR TITLE
fix: align defaultAgentId with OpenClaw default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -230,7 +230,7 @@ export function parseConfig(raw: unknown, resolvePath?: (nextPath: string) => st
       };
     })(),
     routing: {
-      defaultAgentId: asString(routing.defaultAgentId, "default"),
+      defaultAgentId: asString(routing.defaultAgentId, "main"),
       rules: parseRoutingRules(routing.rules),
       ...(routing.affinity != null ? {
         affinity: (() => {
@@ -334,6 +334,7 @@ const plugin = {
       new OpenClawAgentExecutor(api, config),
       telemetry,
       config.limits,
+      config.routing.defaultAgentId,
     );
     const agentCard = buildAgentCard(config);
 

--- a/src/queueing-executor.ts
+++ b/src/queueing-executor.ts
@@ -92,13 +92,15 @@ export class QueueingAgentExecutor implements AgentExecutor {
   private readonly delegate: AgentExecutor;
   private readonly telemetry: GatewayTelemetry;
   private readonly options: QueueingExecutorOptions;
+  private readonly defaultAgentId: string;
   private readonly queue: QueuedTaskEntry[] = [];
   private readonly pendingByTaskId = new Map<string, QueuedTaskEntry>();
   private activeTasks = 0;
 
-  constructor(delegate: AgentExecutor, telemetry: GatewayTelemetry, options: QueueingExecutorOptions) {
+  constructor(delegate: AgentExecutor, telemetry: GatewayTelemetry, options: QueueingExecutorOptions, defaultAgentId = "main") {
     this.delegate = delegate;
     this.telemetry = telemetry;
+    this.defaultAgentId = defaultAgentId;
     this.options = {
       maxConcurrentTasks: Math.max(1, options.maxConcurrentTasks),
       maxQueuedTasks: Math.max(0, options.maxQueuedTasks),
@@ -290,6 +292,6 @@ export class QueueingAgentExecutor implements AgentExecutor {
 
   private pickAgentId(requestContext: RequestContext): string {
     const message = requestContext.userMessage as unknown as Record<string, unknown> | undefined;
-    return typeof message?.agentId === "string" ? message.agentId : "default";
+    return typeof message?.agentId === "string" ? message.agentId : this.defaultAgentId;
   }
 }


### PR DESCRIPTION
## Summary
- Config default `routing.defaultAgentId` changed from `"default"` to `"main"` to match OpenClaw's convention
- `QueueingAgentExecutor` now uses configured default instead of hardcoded `"default"` for telemetry
- All 491 tests pass

## Root Cause
The gateway dispatched to agent `"default"` which OpenClaw rejected as unknown — OpenClaw's default agent is `"main"`.

Closes #57