### PR TITLE
fix: support OpenClaw gateway protocol v4

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -825,7 +825,7 @@ export class GatewayRpcConnection {
 
     const params: Record<string, unknown> = {
       minProtocol: 3,
-      maxProtocol: 3,
+      maxProtocol: 4,
       client: {
         id: "cli",
         version: "a2a-gateway-plugin",

--- a/tests/a2a-gateway.test.ts
+++ b/tests/a2a-gateway.test.ts
@@ -54,9 +54,10 @@ describe("session key format (PR #9, issue #8)", () => {
 
     const originalWebSocket = (globalThis as any).WebSocket;
     (globalThis as any).WebSocket = MockWS;
+    let executor: OpenClawAgentExecutor | undefined;
 
     try {
-      const executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+      executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
 
       await executor.execute(
         {
@@ -97,6 +98,7 @@ describe("session key format (PR #9, issue #8)", () => {
         "session key should follow agent:{agentId}:a2a:{contextId} format"
       );
     } finally {
+      executor?.close();
       (globalThis as any).WebSocket = originalWebSocket;
     }
   });
@@ -162,6 +164,49 @@ describe("a2a-gateway plugin", () => {
       const parts = message.parts as Array<Record<string, unknown>>;
       assert.equal(parts[0].text, "Gateway response");
     } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
+  it("advertises OpenClaw gateway protocol compatibility through version 4", async () => {
+    const api = createApi();
+    let capturedConnectParams: Record<string, unknown> | undefined;
+
+    const MockWS = createMockWebSocketClass({
+      onConnect: (params) => {
+        capturedConnectParams = params;
+        return { status: "ok" };
+      },
+    });
+
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = MockWS;
+    let executor: OpenClawAgentExecutor | undefined;
+
+    try {
+      executor = new OpenClawAgentExecutor(api, makeConfig() as unknown as GatewayConfig);
+
+      await executor.execute(
+        {
+          taskId: "task-protocol",
+          contextId: "ctx-protocol",
+          userMessage: {
+            messageId: "msg-protocol",
+            role: "user",
+            agentId: "writer-agent",
+            parts: [{ kind: "text", text: "test protocol version" }],
+          },
+        } as any,
+        {
+          publish() {},
+          finished() {},
+        } as any
+      );
+
+      assert.equal(capturedConnectParams?.minProtocol, 3);
+      assert.equal(capturedConnectParams?.maxProtocol, 4);
+    } finally {
+      executor?.close();
       (globalThis as any).WebSocket = originalWebSocket;
     }
   });


### PR DESCRIPTION
## Summary
- raise the OpenClaw gateway connect handshake maxProtocol from 3 to 4
- add a targeted regression test for minProtocol/maxProtocol in connect params
- close the session-key test executor after use to avoid leaving pooled websocket timers open

## Validation
- npm install
- npx tsc --noEmit
- node --import tsx --test --test-name-pattern 'advertises OpenClaw gateway protocol compatibility through version 4' tests/a2a-gateway.test.ts
- git diff --check -- src/executor.ts tests/a2a-gateway.test.ts

Note: local npm install updates package-lock.json because the current lockfile is not npm-ci clean on master; that lockfile change is not included in this PR. A full local npm test run was interrupted after the suite stopped producing output; the targeted regression and typecheck passed.

Fixes #73