### PR TITLE
docs: add TweetClaw A2A routing recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ openclaw config set plugins.entries.a2a-gateway.config.security.token "$TOKEN"
 openclaw config set plugins.entries.a2a-gateway.config.routing.defaultAgentId 'main'
 ```
 
+For a concrete peer-skills example, see
+[`docs/SOCIAL-AUTOMATION-ROUTING.md`](./docs/SOCIAL-AUTOMATION-ROUTING.md) for
+routing X/Twitter automation prompts to a TweetClaw-enabled OpenClaw peer.
+
 ### 7. Restart the gateway
 
 ```bash
@@ -482,6 +486,10 @@ node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
 | `routing.rules[].target.peer` | string | *required* | Peer to route to |
 | `routing.rules[].target.agentId` | string | — | Override agentId on the peer |
 | `routing.rules[].priority` | number | `0` | Higher = checked first |
+
+Example: route X/Twitter prompts to a TweetClaw peer by matching both prompt
+language and advertised peer skills. See
+[`docs/SOCIAL-AUTOMATION-ROUTING.md`](./docs/SOCIAL-AUTOMATION-ROUTING.md).
 
 ### Resilience
 

--- a/docs/SOCIAL-AUTOMATION-ROUTING.md
+++ b/docs/SOCIAL-AUTOMATION-ROUTING.md
@@ -1,0 +1,77 @@
+# Route X/Twitter Workflows to a TweetClaw Peer
+
+Use this recipe when one OpenClaw A2A node coordinates general work and a
+separate peer owns X/Twitter automation through
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw).
+
+This keeps social automation credentials on the social peer while the
+coordinator can still route requests such as tweet search, reply search,
+posting drafts, follower export, media upload/download, monitors, webhooks, and
+giveaway draws.
+
+## Topology
+
+| Node | Role | Example Agent ID |
+|------|------|------------------|
+| Coordinator | Receives user requests and routes matching X/Twitter work | `main` |
+| Social-Ops | Runs TweetClaw and advertises X/Twitter skills | `social` |
+
+## 1. Install TweetClaw on the Social-Ops Node
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Configure TweetClaw/Xquik credentials on this node only. Do not put API keys in
+A2A messages, Agent Cards, or shared `TOOLS.md` files.
+
+## 2. Advertise TweetClaw Capabilities in the Agent Card
+
+On the Social-Ops node:
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.name 'Social-Ops'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.description 'OpenClaw peer for TweetClaw X/Twitter automation'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.url 'http://100.10.10.3:18800/a2a/jsonrpc'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.skills '[{"id":"tweet-search","name":"tweet-search","description":"Search tweets and tweet replies"},{"id":"tweet-post","name":"tweet-post","description":"Draft and post tweets or tweet replies with approval"},{"id":"tweet-followers","name":"tweet-followers","description":"Export followers and run user lookup"},{"id":"tweet-media","name":"tweet-media","description":"Upload and download tweet media"},{"id":"tweet-monitor","name":"tweet-monitor","description":"Monitor tweets, webhooks, and giveaway draws"}]'
+openclaw config set plugins.entries.a2a-gateway.config.routing.defaultAgentId 'social'
+openclaw gateway restart
+```
+
+Verify the public Agent Card:
+
+```bash
+curl -s http://100.10.10.3:18800/.well-known/agent-card.json | python3 -m json.tool
+```
+
+## 3. Add the Social-Ops Peer to the Coordinator
+
+On the Coordinator node:
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.peers '[{"name":"Social-Ops","agentCardUrl":"http://100.10.10.3:18800/.well-known/agent-card.json","auth":{"type":"bearer","token":"<SOCIAL_OPS_TOKEN>"}}]'
+```
+
+## 4. Route Matching Requests by Pattern and Peer Skills
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.routing.rules '[{"name":"x-twitter-automation","match":{"pattern":"\\b(tweet|tweets|reply|replies|twitter|x/twitter|x api|follower|followers|user lookup|media|direct messages?|dms?|webhook|giveaway)\\b","skills":["tweet-search","tweet-post","tweet-monitor","tweet-followers","tweet-media"]},"target":{"peer":"Social-Ops","agentId":"social"},"priority":100}]'
+openclaw gateway restart
+```
+
+The rule is intentionally broad enough for user language such as "search tweets
+about OpenClaw", "post this reply", "export followers", "monitor this account",
+"send a direct message", or "run a giveaway draw".
+
+## 5. Test the Route
+
+```bash
+node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
+  --peer-url http://100.10.10.3:18800 \
+  --token <SOCIAL_OPS_TOKEN> \
+  --agent-id social \
+  --message "Search tweets about OpenClaw plugins and summarize the top themes."
+```
+
+For write actions, ask the Social-Ops peer to draft first and request explicit
+approval before posting.

--- a/docs/SOCIAL-AUTOMATION-ROUTING.md
+++ b/docs/SOCIAL-AUTOMATION-ROUTING.md
@@ -63,15 +63,45 @@ The rule is intentionally broad enough for user language such as "search tweets
 about OpenClaw", "post this reply", "export followers", "monitor this account",
 "send a direct message", or "run a giveaway draw".
 
-## 5. Test the Route
+## 5. Test Direct Peer Connectivity
 
 ```bash
 node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
   --peer-url http://100.10.10.3:18800 \
   --token <SOCIAL_OPS_TOKEN> \
   --agent-id social \
-  --message "Search tweets about OpenClaw plugins and summarize the top themes."
+  --message "Reply with your Agent Card name and advertised TweetClaw skills."
 ```
+
+This only proves the Social-Ops peer is reachable. It does not exercise the
+Coordinator routing rule.
+
+## 6. Test the Coordinator Route
+
+On the Coordinator node, invoke the OpenClaw gateway method `a2a.send` with no
+`peer` or `name` parameter:
+
+```json
+{
+  "method": "a2a.send",
+  "params": {
+    "message": {
+      "text": "Search tweets about OpenClaw plugins and summarize the top themes."
+    }
+  }
+}
+```
+
+Use the Coordinator gateway endpoint and Coordinator gateway auth token for this
+request, not the Social-Ops A2A endpoint or token. Expected behavior:
+
+- `routing.rules` matches the tweet search wording.
+- the cached Social-Ops Agent Card skills satisfy the TweetClaw skill match.
+- the Coordinator forwards the message to peer `Social-Ops` with `agentId`
+  `social`.
+
+Do not include `peer` or `name` while testing routing. Explicit peer selection
+bypasses routing rules and can hide a broken rule.
 
 For write actions, ask the Social-Ops peer to draft first and request explicit
 approval before posting.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -93,6 +93,10 @@ Share this token with peers who need to send you messages.
 openclaw config set plugins.entries.a2a-gateway.config.routing.defaultAgentId 'main'
 ```
 
+For a concrete peer-skills route, read
+`docs/SOCIAL-AUTOMATION-ROUTING.md`. It shows how to route X/Twitter prompts to
+a TweetClaw-enabled peer while keeping credentials on that peer.
+
 ## Step 7: Add Peers
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a social automation routing recipe for delegating X/Twitter work to a TweetClaw-enabled OpenClaw peer.
- Show concrete Agent Card skills, peer registration, routing.rules config, a direct peer connectivity check, and a Coordinator-side route test through `a2a.send` without an explicit peer.
- Link the recipe from the README routing setup and the bundled a2a-setup skill.

## Why this helps
- Demonstrates the existing peer-skills routing feature with a concrete OpenClaw plugin workflow.
- Keeps TweetClaw/Xquik credentials on the social automation node instead of sending secrets through A2A messages or shared TOOLS.md files.
- Covers common user intents: search tweets, search tweet replies, post tweets/replies with approval, follower export, user lookup, media upload/download, direct messages, monitors, webhooks, and giveaway draws.

## Validation
- `git diff --cached --check`
- `git diff --check`
- Parsed all JSON snippets embedded in `docs/SOCIAL-AUTOMATION-ROUTING.md`
- Checked relevant external links: TweetClaw, OpenClaw, and A2A links resolve
- `npm view @xquik/tweetclaw version openclaw.install --json` -> `1.6.31`, npm spec `@xquik/tweetclaw@1.6.31`, min host `>=2026.5.4`
- `node --import tsx --test tests/routing-rules.test.ts`
- `node --import tsx --test tests/peer-health.test.ts`

## Notes
- `npm ci` is currently blocked on upstream because `package.json` and `package-lock.json` are out of sync before this docs change.
- After `npm install --no-package-lock --no-audit --no-fund`, full `npm test` started with passing groups but stopped emitting output for over 60 seconds, so I interrupted it and ran the routing-focused tests above.