### PR TITLE
fix: resolve blocking A2A agent event responses

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -921,6 +921,24 @@ export class GatewayRpcConnection {
         if (nonce && this.connectChallengeResolver) {
           this.connectChallengeResolver(nonce);
         }
+        return;
+      }
+
+      if (frame.event === "agent") {
+        const eventPayload = asObject(frame.payload);
+        const eventResult = asObject(eventPayload?.result);
+        const eventPayloads = Array.isArray(eventResult?.payloads) ? eventResult.payloads : [];
+        const hasAgentContent = eventPayloads.some((entry) => Boolean(extractAgentPayloadText(entry)) || extractMediaUrlsFromPayload(entry).length > 0);
+        if (hasAgentContent) {
+          const pendingEntries = Array.from(this.pending.entries())
+            .filter(([, entry]) => entry.expectFinal && entry.method === "agent");
+          if (pendingEntries.length === 1) {
+            const [pendingId, pending] = pendingEntries[0];
+            this.pending.delete(pendingId);
+            clearTimeout(pending.timer);
+            pending.resolve(frame.payload);
+          }
+        }
       }
       return;
     }

--- a/tests/blocking-agent-event.test.ts
+++ b/tests/blocking-agent-event.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { GatewayRpcConnection } from "../src/executor.ts";
+
+function makeConnection(): GatewayRpcConnection {
+  return new GatewayRpcConnection({
+    port: 18789,
+    wsUrl: "ws://127.0.0.1:18789/ws",
+    hooksWakeUrl: "http://127.0.0.1:18789/hooks/wake",
+    gatewayToken: "",
+    gatewayPassword: "",
+    hooksToken: "",
+  });
+}
+
+test("event=agent with final payload resolves pending expectFinal agent request", async () => {
+  const conn = makeConnection() as unknown as {
+    pending: Map<string, unknown>;
+    handleMessage(event: { data: unknown }): void;
+  };
+
+  let resolved: unknown;
+  const timer = setTimeout(() => {}, 10_000);
+  conn.pending.set("pending-agent", {
+    method: "agent",
+    expectFinal: true,
+    timer,
+    resolve: (value: unknown) => { resolved = value; },
+    reject: (error: Error) => { throw error; },
+  });
+
+  const finalPayload = {
+    status: "ok",
+    result: {
+      payloads: [
+        { type: "message", role: "assistant", content: [{ type: "text", text: "A2A_V260_READINESS_OK" }] },
+      ],
+    },
+  };
+
+  conn.handleMessage({
+    data: JSON.stringify({ type: "event", event: "agent", payload: finalPayload }),
+  });
+
+  clearTimeout(timer);
+  assert.equal(conn.pending.size, 0);
+  assert.deepEqual(resolved, finalPayload);
+});
+
+test("event=agent without content does not resolve pending expectFinal agent request", () => {
+  const conn = makeConnection() as unknown as {
+    pending: Map<string, unknown>;
+    handleMessage(event: { data: unknown }): void;
+  };
+
+  let resolved = false;
+  const timer = setTimeout(() => {}, 10_000);
+  conn.pending.set("pending-agent", {
+    method: "agent",
+    expectFinal: true,
+    timer,
+    resolve: () => { resolved = true; },
+    reject: (error: Error) => { throw error; },
+  });
+
+  conn.handleMessage({
+    data: JSON.stringify({ type: "event", event: "agent", payload: { status: "working" } }),
+  });
+
+  clearTimeout(timer);
+  assert.equal(conn.pending.size, 1);
+  assert.equal(resolved, false);
+});


### PR DESCRIPTION
## Summary
- Fixes blocking A2A `message/send` calls timing out after an `agent` RPC is acknowledged as `accepted`.
- Handles final `event=agent` frames that contain real assistant text/media payloads but do not carry the original request id.
- Resolves the single pending `expectFinal` agent request only when content is present, avoiding early resolution on progress/empty agent events.
- Adds a targeted regression test for final agent event resolution and non-content agent events.

## Validation
- `npx tsc --noEmit --pretty false`
- `node --import tsx --test tests/blocking-agent-event.test.ts`

## Live evidence
This was validated against a live Hermes ↔ OpenClaw A2A setup before opening the PR. The previously blocked `message/send` call produced final two-worker evidence with:

- `ok=true`
- `receipt_count=2`
- `accepted_count=2`
- `overall=accepted_with_boundary`

Hermes-side evidence is tracked in NousResearch/hermes-agent PR #35318.
