### PR TITLE
docs: add GetXAPI A2A routing recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ openclaw config set plugins.entries.a2a-gateway.config.routing.defaultAgentId 'm
 For a concrete peer-skills example, see
 [`docs/SOCIAL-AUTOMATION-ROUTING.md`](./docs/SOCIAL-AUTOMATION-ROUTING.md) for
 routing X/Twitter automation prompts to a TweetClaw-enabled OpenClaw peer.
+For routing X/Twitter read traffic to a GetXAPI-backed peer, see
+[`docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md`](./docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md).
 
 ### 7. Restart the gateway
 
@@ -491,6 +493,8 @@ node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
 Example: route X/Twitter prompts to a TweetClaw peer by matching both prompt
 language and advertised peer skills. See
 [`docs/SOCIAL-AUTOMATION-ROUTING.md`](./docs/SOCIAL-AUTOMATION-ROUTING.md).
+For routing X/Twitter read traffic to a GetXAPI peer, see
+[`docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md`](./docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md).
 
 ### Resilience
 

--- a/docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md
+++ b/docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md
@@ -19,12 +19,15 @@ TweetClaw peer and reads to a GetXAPI peer.
 ## 1. Configure GetXAPI on the Social-Read Node
 
 ```bash
-export GETXAPI_API_KEY=...
-export GETXAPI_ENABLE_ACTIONS=false
+export GETXAPI_KEY=...
 ```
 
-`GETXAPI_ENABLE_ACTIONS=false` keeps the backend read-only. Do not put
-`GETXAPI_API_KEY` in A2A messages, Agent Cards, or shared `TOOLS.md` files.
+The backend is read-only when only `GETXAPI_KEY` is set — read endpoints
+(search, profile, timeline, follower graph) work with the API key alone.
+Write endpoints additionally require X account auth (`X_AUTH_TOKEN`,
+`X_CT0`, `X_TWID`) or an `x_login` flow, which are intentionally not set on
+a read-only node. Do not put `GETXAPI_KEY` in A2A messages, Agent Cards,
+or shared `TOOLS.md` files.
 
 ## 2. Advertise GetXAPI Read Skills in the Agent Card
 
@@ -100,7 +103,7 @@ Expected behavior:
 ## GetXAPI Endpoint Reference
 
 - `GET https://api.getxapi.com/twitter/tweet/advanced_search?q=<query>`
-- Header: `Authorization: Bearer ${GETXAPI_API_KEY}`
+- Header: `Authorization: Bearer ${GETXAPI_KEY}`
 
 For write actions, keep routing them to a TweetClaw peer per
 `SOCIAL-AUTOMATION-ROUTING.md`. GetXAPI in this recipe stays read-only.

--- a/docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md
+++ b/docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md
@@ -1,0 +1,106 @@
+# Route X/Twitter Read Workflows to a GetXAPI Peer
+
+Use this recipe when one OpenClaw A2A node coordinates general work and a
+separate peer owns X/Twitter read traffic through
+[GetXAPI](https://github.com/getxapi/getxapi-mcp).
+
+This is the read-backend companion to the TweetClaw recipe in
+[`SOCIAL-AUTOMATION-ROUTING.md`](./SOCIAL-AUTOMATION-ROUTING.md). The two
+recipes are not mutually exclusive: a deployment can route writes to a
+TweetClaw peer and reads to a GetXAPI peer.
+
+## Topology
+
+| Node | Role | Example Agent ID |
+|------|------|------------------|
+| Coordinator | Receives user requests and routes matching X/Twitter reads | `main` |
+| Social-Read | Runs a GetXAPI-backed agent and advertises read skills | `read` |
+
+## 1. Configure GetXAPI on the Social-Read Node
+
+```bash
+export GETXAPI_API_KEY=...
+export GETXAPI_ENABLE_ACTIONS=false
+```
+
+`GETXAPI_ENABLE_ACTIONS=false` keeps the backend read-only. Do not put
+`GETXAPI_API_KEY` in A2A messages, Agent Cards, or shared `TOOLS.md` files.
+
+## 2. Advertise GetXAPI Read Skills in the Agent Card
+
+On the Social-Read node:
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.name 'Social-Read'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.description 'OpenClaw peer for GetXAPI X/Twitter reads'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.url 'http://100.10.10.4:18800/a2a/jsonrpc'
+openclaw config set plugins.entries.a2a-gateway.config.agentCard.skills '[{"id":"tweet-advanced-search","name":"tweet-advanced-search","description":"Search tweets via GetXAPI advanced_search"},{"id":"tweet-user-lookup","name":"tweet-user-lookup","description":"Look up users and timelines"},{"id":"tweet-replies","name":"tweet-replies","description":"Fetch replies to a tweet"}]'
+openclaw config set plugins.entries.a2a-gateway.config.routing.defaultAgentId 'read'
+openclaw gateway restart
+```
+
+Verify the public Agent Card:
+
+```bash
+curl -s http://100.10.10.4:18800/.well-known/agent-card.json | python3 -m json.tool
+```
+
+## 3. Add the Social-Read Peer to the Coordinator
+
+On the Coordinator node:
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.peers '[{"name":"Social-Read","agentCardUrl":"http://100.10.10.4:18800/.well-known/agent-card.json","auth":{"type":"bearer","token":"<SOCIAL_READ_TOKEN>"}}]'
+```
+
+## 4. Route Read-Shaped Requests to the GetXAPI Peer
+
+```bash
+openclaw config set plugins.entries.a2a-gateway.config.routing.rules '[{"name":"x-twitter-reads","match":{"pattern":"\\b(search tweets?|find tweets?|look up|user timeline|replies to|fetch tweet)\\b","skills":["tweet-advanced-search","tweet-user-lookup","tweet-replies"]},"target":{"peer":"Social-Read","agentId":"read"},"priority":90}]'
+openclaw gateway restart
+```
+
+The pattern matches read-shaped wording such as "search tweets about X",
+"look up @user", or "fetch replies to this tweet". Pair with the
+TweetClaw routing rule from `SOCIAL-AUTOMATION-ROUTING.md` at a higher
+priority if write phrasing should still go to the TweetClaw peer.
+
+## 5. Test Direct Peer Connectivity
+
+```bash
+node <PLUGIN_PATH>/skill/scripts/a2a-send.mjs \
+  --peer-url http://100.10.10.4:18800 \
+  --token <SOCIAL_READ_TOKEN> \
+  --agent-id read \
+  --message "Reply with your Agent Card name and advertised GetXAPI read skills."
+```
+
+## 6. Test the Coordinator Route
+
+On the Coordinator node, invoke `a2a.send` with no `peer` or `name`:
+
+```json
+{
+  "method": "a2a.send",
+  "params": {
+    "message": {
+      "text": "Search tweets about OpenClaw plugins and summarize the top themes."
+    }
+  }
+}
+```
+
+Expected behavior:
+
+- `routing.rules` matches the read wording.
+- the cached Social-Read Agent Card skills satisfy the GetXAPI skill match.
+- the Coordinator forwards the message to peer `Social-Read` with `agentId`
+  `read`.
+
+## GetXAPI Endpoint Reference
+
+- `GET https://api.getxapi.com/twitter/tweet/advanced_search?q=<query>`
+- Header: `Authorization: Bearer ${GETXAPI_API_KEY}`
+
+For write actions, keep routing them to a TweetClaw peer per
+`SOCIAL-AUTOMATION-ROUTING.md`. GetXAPI in this recipe stays read-only.


### PR DESCRIPTION
## Summary

- Add an optional GetXAPI A2A routing recipe alongside the TweetClaw recipe (introduced in PR #76 by @kriptoburak).
- Documentation-only change. Mirrors the TweetClaw companion recipe from PR #76 with a parallel read-focused doc.
- New file: `docs/SOCIAL-AUTOMATION-ROUTING-GETXAPI.md` covering peer Agent Card setup, routing rules, and connectivity tests for a GetXAPI-backed peer.
- README cross-references added next to existing TweetClaw cross-references (no replacement).

## Backward compatibility

Fully backward compatible. Existing TweetClaw recipe unchanged. GetXAPI recipe is purely additive.

## Links

- Endpoint: `GET https://api.getxapi.com/twitter/tweet/advanced_search`
- Auth: Bearer token
- Repo: https://github.com/getxapi/getxapi-mcp
- Wikidata: https://www.wikidata.org/wiki/Q139996278
- Crunchbase: https://www.crunchbase.com/organization/getxapi

I checked existing GetXAPI / TwitterAPI.io / Xquik / TweetClaw / Hermes Tweet code, open PRs, closed PRs, and closed issues in this repository before opening this PR. No existing GetXAPI submission found.