### PR TITLE
fix: remove deprecated grpcServer.start() call

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -967,11 +967,9 @@ const plugin = {
                   resolve(); // Non-fatal: HTTP still works
                   return;
                 }
-                try {
-                  grpcServer!.start();
-                } catch {
-                  // ignore: some grpc-js versions auto-start
-                }
+                // grpc-js >=1.10 auto-starts on bindAsync; start() is a no-op that
+                // emits a DeprecationWarning. Omit it entirely.
+                // https://grpc.github.io/grpc/node/grpc.Server.html#start
                 api.logger.info(
                   `a2a-gateway: gRPC listening on ${config.server.host}:${grpcPort}`
                 );


### PR DESCRIPTION
## Problem

`grpcServer.start()` in `index.ts` triggers a Node.js DeprecationWarning:

```
DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
```

Since grpc-js >=1.10, the server auto-starts on `bindAsync()`. The `start()` call is now a no-op that emits a deprecation warning via `process.emitWarning()`. In OpenClaw, this surfaces as a diagnostic error in the status panel.

## Fix

Remove the `try { grpcServer.start() } catch {}` block entirely. `bindAsync()` already handles server startup — the explicit `start()` call is unnecessary.

## Before
```typescript
try {
  grpcServer!.start();
} catch {
  // ignore: some grpc-js versions auto-start
}
```

## After
```typescript
// grpc-js >=1.10 auto-starts on bindAsync; start() is a no-op that
// emits a DeprecationWarning. Omit it entirely.
// https://grpc.github.io/grpc/node/grpc.Server.html#start
```

Verified: gRPC server listens correctly on port+1 without the call. No deprecation warning emitted.