### PR TITLE
fix: serialize dispatch per contextId to prevent race condition (#81)

### DIFF
--- a/src/dispatch-queue.ts
+++ b/src/dispatch-queue.ts
@@ -1,0 +1,58 @@
+/**
+ * Per-key dispatch queue for serializing concurrent async operations.
+ *
+ * Used by the A2A gateway executor to serialize tasks sharing the same
+ * contextId, preventing race conditions on the session .jsonl file.
+ *
+ * @see https://github.com/win4r/openclaw-a2a-gateway/issues/81
+ */
+
+/**
+ * Enqueue an async operation so it runs after any pending operation for the
+ * same key has settled. Operations for different keys run concurrently.
+ *
+ * - Failure isolation: a rejected predecessor does not cascade.
+ * - Cleanup: the map entry is removed when the chain settles.
+ *
+ * @param queues  Shared map of key → tail promise
+ * @param key     Queue key (e.g. contextId)
+ * @param fn      The async operation to enqueue
+ * @returns       Result of `fn`, after serialization
+ */
+export function enqueueDispatch<T>(
+  queues: Map<string, Promise<void>>,
+  key: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = queues.get(key) ?? Promise.resolve();
+
+  let resolveDispatch: (value: T) => void;
+  let rejectDispatch: (error: unknown) => void;
+  const resultPromise = new Promise<T>((resolve, reject) => {
+    resolveDispatch = resolve;
+    rejectDispatch = reject;
+  });
+
+  // Chain: swallow predecessor errors so one failure doesn't cascade
+  const chain = previous.catch(() => {}).then(async () => {
+    try {
+      const result = await fn();
+      resolveDispatch(result);
+    } catch (err) {
+      rejectDispatch(err);
+    }
+  });
+
+  queues.set(key, chain);
+
+  // Cleanup: remove entry if this is still the tail promise
+  chain
+    .finally(() => {
+      if (queues.get(key) === chain) {
+        queues.delete(key);
+      }
+    })
+    .catch(() => {}); // suppress unhandled rejection on cleanup
+
+  return resultPromise;
+}

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1255,6 +1255,8 @@ export class OpenClawAgentExecutor implements AgentExecutor {
   private readonly security: GatewayConfig["security"];
   private readonly taskContextByTaskId: Map<string, string>;
   private readonly wsPool: GatewayRpcConnectionPool;
+  /** Per-contextId dispatch queue to serialize concurrent tasks sharing a context. */
+  private readonly dispatchQueues = new Map<string, Promise<void>>();
 
   constructor(api: OpenClawPluginApi, config: GatewayConfig) {
     this.api = api;
@@ -1354,7 +1356,10 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     }, STREAMING_HEARTBEAT_INTERVAL_MS);
 
     try {
-      agentResponse = await this.dispatchViaGatewayRpc(agentId, requestContext.userMessage, contextId);
+      // Serialize dispatch per contextId to prevent race conditions on the
+      // session .jsonl file when two tasks share the same contextId.
+      // See: https://github.com/win4r/openclaw-a2a-gateway/issues/81
+      agentResponse = await this.enqueueDispatch(contextId, agentId, requestContext.userMessage);
     } catch (err: unknown) {
       clearInterval(heartbeat);
       const errorMessage = err instanceof Error ? err.message : String(err);
@@ -1465,6 +1470,52 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     }
   }
 
+
+  /**
+   * Serialize agent dispatch per contextId to prevent race conditions.
+   * Tasks sharing the same contextId are chained so only one dispatches at a time.
+   * Failed tasks do not poison the chain for subsequent tasks.
+   * The queue entry is cleaned up after the chain settles.
+   *
+   * @see https://github.com/win4r/openclaw-a2a-gateway/issues/81
+   */
+  private enqueueDispatch(
+    contextId: string,
+    agentId: string,
+    userMessage: unknown,
+  ): Promise<AgentResponse> {
+    const previous = this.dispatchQueues.get(contextId) ?? Promise.resolve();
+
+    // The queue tracks void (completion), but we need to return AgentResponse.
+    // We create a chained promise that dispatches after the previous one settles.
+    let resolveDispatch: (value: AgentResponse) => void;
+    let rejectDispatch: (error: unknown) => void;
+    const resultPromise = new Promise<AgentResponse>((resolve, reject) => {
+      resolveDispatch = resolve;
+      rejectDispatch = reject;
+    });
+
+    // Chain: swallow predecessor errors so one failure doesn't cascade
+    const chain = previous.catch(() => {}).then(async () => {
+      try {
+        const response = await this.dispatchViaGatewayRpc(agentId, userMessage, contextId);
+        resolveDispatch(response);
+      } catch (err) {
+        rejectDispatch(err);
+      }
+    });
+
+    this.dispatchQueues.set(contextId, chain);
+
+    // Cleanup: remove entry if this is still the tail promise
+    chain.finally(() => {
+      if (this.dispatchQueues.get(contextId) === chain) {
+        this.dispatchQueues.delete(contextId);
+      }
+    }).catch(() => {}); // suppress unhandled rejection on cleanup
+
+    return resultPromise;
+  }
 
   private async dispatchViaGatewayRpc(
     agentId: string,

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -8,6 +8,7 @@ import type { Message, Part, Task } from "@a2a-js/sdk";
 import type { AgentExecutor, ExecutionEventBus, RequestContext } from "@a2a-js/sdk/server";
 
 import type { GatewayConfig, OpenClawPluginApi } from "./types.js";
+import { enqueueDispatch } from "./dispatch-queue.js";
 import {
   validateMimeType,
   validateUriSchemeAndIp,
@@ -1359,7 +1360,9 @@ export class OpenClawAgentExecutor implements AgentExecutor {
       // Serialize dispatch per contextId to prevent race conditions on the
       // session .jsonl file when two tasks share the same contextId.
       // See: https://github.com/win4r/openclaw-a2a-gateway/issues/81
-      agentResponse = await this.enqueueDispatch(contextId, agentId, requestContext.userMessage);
+      agentResponse = await enqueueDispatch(this.dispatchQueues, contextId, () =>
+        this.dispatchViaGatewayRpc(agentId, requestContext.userMessage, contextId),
+      );
     } catch (err: unknown) {
       clearInterval(heartbeat);
       const errorMessage = err instanceof Error ? err.message : String(err);
@@ -1470,52 +1473,6 @@ export class OpenClawAgentExecutor implements AgentExecutor {
     }
   }
 
-
-  /**
-   * Serialize agent dispatch per contextId to prevent race conditions.
-   * Tasks sharing the same contextId are chained so only one dispatches at a time.
-   * Failed tasks do not poison the chain for subsequent tasks.
-   * The queue entry is cleaned up after the chain settles.
-   *
-   * @see https://github.com/win4r/openclaw-a2a-gateway/issues/81
-   */
-  private enqueueDispatch(
-    contextId: string,
-    agentId: string,
-    userMessage: unknown,
-  ): Promise<AgentResponse> {
-    const previous = this.dispatchQueues.get(contextId) ?? Promise.resolve();
-
-    // The queue tracks void (completion), but we need to return AgentResponse.
-    // We create a chained promise that dispatches after the previous one settles.
-    let resolveDispatch: (value: AgentResponse) => void;
-    let rejectDispatch: (error: unknown) => void;
-    const resultPromise = new Promise<AgentResponse>((resolve, reject) => {
-      resolveDispatch = resolve;
-      rejectDispatch = reject;
-    });
-
-    // Chain: swallow predecessor errors so one failure doesn't cascade
-    const chain = previous.catch(() => {}).then(async () => {
-      try {
-        const response = await this.dispatchViaGatewayRpc(agentId, userMessage, contextId);
-        resolveDispatch(response);
-      } catch (err) {
-        rejectDispatch(err);
-      }
-    });
-
-    this.dispatchQueues.set(contextId, chain);
-
-    // Cleanup: remove entry if this is still the tail promise
-    chain.finally(() => {
-      if (this.dispatchQueues.get(contextId) === chain) {
-        this.dispatchQueues.delete(contextId);
-      }
-    }).catch(() => {}); // suppress unhandled rejection on cleanup
-
-    return resultPromise;
-  }
 
   private async dispatchViaGatewayRpc(
     agentId: string,

--- a/tests/context-dispatch-queue.test.ts
+++ b/tests/context-dispatch-queue.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for per-contextId dispatch queue serialization.
+ *
+ * Verifies that concurrent A2A tasks sharing the same contextId are
+ * dispatched sequentially to prevent race conditions on the session file.
+ *
+ * @see https://github.com/win4r/openclaw-a2a-gateway/issues/81
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createMockWebSocketClass, createEventBus, makeConfig, registerPlugin } from "./helpers.js";
+
+describe("per-contextId dispatch queue", () => {
+  it("serializes two concurrent tasks with the same contextId", async () => {
+    const dispatchLog: string[] = [];
+    const completionOrder: string[] = [];
+
+    // Track dispatch calls with a delay to simulate real agent work
+    const MockWebSocket = createMockWebSocketClass({
+      agentResponseText: "response",
+      onAgent: (params) => {
+        const taskId = params.taskId as string;
+        dispatchLog.push(`dispatch:${taskId}`);
+      },
+    });
+
+    const config = makeConfig({
+      peers: [],
+    });
+
+    const { service } = registerPlugin(config);
+
+    // Patch the WebSocket class on the service internals
+    // We'll test the queue behavior indirectly by verifying dispatch order
+    assert(service, "service should be registered");
+
+    // For a direct unit test of the queue logic, we instantiate the executor
+    // and verify the chaining behavior.
+    //
+    // Since the executor is tightly coupled to the WS transport, we verify
+    // the integration behavior: two tasks with same contextId should not
+    // dispatch concurrently.
+
+    // Simulate the queue behavior manually
+    const { OpenClawAgentExecutor } = await import("../src/executor.js");
+
+    // We can't easily instantiate the executor without the full plugin context,
+    // so we test the queue pattern directly as a standalone verification.
+    const dispatchQueues = new Map();
+
+    function enqueueDispatch(contextId, dispatchFn) {
+      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
+
+      let resolveDispatch;
+      let rejectDispatch;
+      const resultPromise = new Promise((resolve, reject) => {
+        resolveDispatch = resolve;
+        rejectDispatch = reject;
+      });
+
+      const chain = previous.catch(() => {}).then(async () => {
+        try {
+          const result = await dispatchFn();
+          resolveDispatch(result);
+        } catch (err) {
+          rejectDispatch(err);
+        }
+      });
+
+      dispatchQueues.set(contextId, chain);
+
+      chain.finally(() => {
+        if (dispatchQueues.get(contextId) === chain) {
+          dispatchQueues.delete(contextId);
+        }
+      }).catch(() => {});
+
+      return resultPromise;
+    }
+
+    // Test: two tasks with same contextId are serialized
+    const order = [];
+
+    async function task1() {
+      order.push("task1:start");
+      await new Promise((r) => setTimeout(r, 50));
+      order.push("task1:end");
+      return "result1";
+    }
+
+    async function task2() {
+      order.push("task2:start");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("task2:end");
+      return "result2";
+    }
+
+    const [r1, r2] = await Promise.all([
+      enqueueDispatch("ctx-1", task1),
+      enqueueDispatch("ctx-1", task2),
+    ]);
+
+    assert.equal(r1, "result1");
+    assert.equal(r2, "result2");
+
+    // task1 must fully complete before task2 starts
+    assert.deepEqual(order, ["task1:start", "task1:end", "task2:start", "task2:end"]);
+  });
+
+  it("allows concurrent dispatch for different contextIds", async () => {
+    const dispatchQueues = new Map();
+
+    function enqueueDispatch(contextId, dispatchFn) {
+      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
+
+      let resolveDispatch;
+      let rejectDispatch;
+      const resultPromise = new Promise((resolve, reject) => {
+        resolveDispatch = resolve;
+        rejectDispatch = reject;
+      });
+
+      const chain = previous.catch(() => {}).then(async () => {
+        try {
+          const result = await dispatchFn();
+          resolveDispatch(result);
+        } catch (err) {
+          rejectDispatch(err);
+        }
+      });
+
+      dispatchQueues.set(contextId, chain);
+
+      chain.finally(() => {
+        if (dispatchQueues.get(contextId) === chain) {
+          dispatchQueues.delete(contextId);
+        }
+      }).catch(() => {});
+
+      return resultPromise;
+    }
+
+    const order = [];
+
+    async function taskA() {
+      order.push("A:start");
+      await new Promise((r) => setTimeout(r, 50));
+      order.push("A:end");
+      return "A";
+    }
+
+    async function taskB() {
+      order.push("B:start");
+      await new Promise((r) => setTimeout(r, 10));
+      order.push("B:end");
+      return "B";
+    }
+
+    // Different contextIds — should run concurrently
+    const [rA, rB] = await Promise.all([
+      enqueueDispatch("ctx-1", taskA),
+      enqueueDispatch("ctx-2", taskB),
+    ]);
+
+    assert.equal(rA, "A");
+    assert.equal(rB, "B");
+
+    // B should start before A ends (concurrent execution)
+    assert.ok(order.indexOf("B:start") < order.indexOf("A:end"),
+      `Expected B to start before A ends. Order: ${JSON.stringify(order)}`);
+  });
+
+  it("does not poison the chain when a task fails", async () => {
+    const dispatchQueues = new Map();
+
+    function enqueueDispatch(contextId, dispatchFn) {
+      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
+
+      let resolveDispatch;
+      let rejectDispatch;
+      const resultPromise = new Promise((resolve, reject) => {
+        resolveDispatch = resolve;
+        rejectDispatch = reject;
+      });
+
+      const chain = previous.catch(() => {}).then(async () => {
+        try {
+          const result = await dispatchFn();
+          resolveDispatch(result);
+        } catch (err) {
+          rejectDispatch(err);
+        }
+      });
+
+      dispatchQueues.set(contextId, chain);
+
+      chain.finally(() => {
+        if (dispatchQueues.get(contextId) === chain) {
+          dispatchQueues.delete(contextId);
+        }
+      }).catch(() => {});
+
+      return resultPromise;
+    }
+
+    const order = [];
+
+    async function failingTask() {
+      order.push("fail:start");
+      throw new Error("boom");
+    }
+
+    async function successTask() {
+      order.push("success:start");
+      return "ok";
+    }
+
+    // First task fails, second should still run
+    await assert.rejects(() => enqueueDispatch("ctx-1", failingTask), { message: "boom" });
+    const result = await enqueueDispatch("ctx-1", successTask);
+
+    assert.equal(result, "ok");
+    assert.deepEqual(order, ["fail:start", "success:start"]);
+  });
+});

--- a/tests/context-dispatch-queue.test.ts
+++ b/tests/context-dispatch-queue.test.ts
@@ -1,86 +1,21 @@
 /**
  * Tests for per-contextId dispatch queue serialization.
  *
- * Verifies that concurrent A2A tasks sharing the same contextId are
- * dispatched sequentially to prevent race conditions on the session file.
+ * Exercises the real enqueueDispatch() helper from src/dispatch-queue.ts
+ * to verify that concurrent A2A tasks sharing the same contextId are
+ * dispatched sequentially, preventing race conditions on the session file.
  *
  * @see https://github.com/win4r/openclaw-a2a-gateway/issues/81
  */
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { createMockWebSocketClass, createEventBus, makeConfig, registerPlugin } from "./helpers.js";
+import { enqueueDispatch } from "../src/dispatch-queue.js";
 
 describe("per-contextId dispatch queue", () => {
   it("serializes two concurrent tasks with the same contextId", async () => {
-    const dispatchLog: string[] = [];
-    const completionOrder: string[] = [];
-
-    // Track dispatch calls with a delay to simulate real agent work
-    const MockWebSocket = createMockWebSocketClass({
-      agentResponseText: "response",
-      onAgent: (params) => {
-        const taskId = params.taskId as string;
-        dispatchLog.push(`dispatch:${taskId}`);
-      },
-    });
-
-    const config = makeConfig({
-      peers: [],
-    });
-
-    const { service } = registerPlugin(config);
-
-    // Patch the WebSocket class on the service internals
-    // We'll test the queue behavior indirectly by verifying dispatch order
-    assert(service, "service should be registered");
-
-    // For a direct unit test of the queue logic, we instantiate the executor
-    // and verify the chaining behavior.
-    //
-    // Since the executor is tightly coupled to the WS transport, we verify
-    // the integration behavior: two tasks with same contextId should not
-    // dispatch concurrently.
-
-    // Simulate the queue behavior manually
-    const { OpenClawAgentExecutor } = await import("../src/executor.js");
-
-    // We can't easily instantiate the executor without the full plugin context,
-    // so we test the queue pattern directly as a standalone verification.
-    const dispatchQueues = new Map();
-
-    function enqueueDispatch(contextId, dispatchFn) {
-      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
-
-      let resolveDispatch;
-      let rejectDispatch;
-      const resultPromise = new Promise((resolve, reject) => {
-        resolveDispatch = resolve;
-        rejectDispatch = reject;
-      });
-
-      const chain = previous.catch(() => {}).then(async () => {
-        try {
-          const result = await dispatchFn();
-          resolveDispatch(result);
-        } catch (err) {
-          rejectDispatch(err);
-        }
-      });
-
-      dispatchQueues.set(contextId, chain);
-
-      chain.finally(() => {
-        if (dispatchQueues.get(contextId) === chain) {
-          dispatchQueues.delete(contextId);
-        }
-      }).catch(() => {});
-
-      return resultPromise;
-    }
-
-    // Test: two tasks with same contextId are serialized
-    const order = [];
+    const queues = new Map<string, Promise<void>>();
+    const order: string[] = [];
 
     async function task1() {
       order.push("task1:start");
@@ -97,8 +32,8 @@ describe("per-contextId dispatch queue", () => {
     }
 
     const [r1, r2] = await Promise.all([
-      enqueueDispatch("ctx-1", task1),
-      enqueueDispatch("ctx-1", task2),
+      enqueueDispatch(queues, "ctx-1", task1),
+      enqueueDispatch(queues, "ctx-1", task2),
     ]);
 
     assert.equal(r1, "result1");
@@ -109,39 +44,8 @@ describe("per-contextId dispatch queue", () => {
   });
 
   it("allows concurrent dispatch for different contextIds", async () => {
-    const dispatchQueues = new Map();
-
-    function enqueueDispatch(contextId, dispatchFn) {
-      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
-
-      let resolveDispatch;
-      let rejectDispatch;
-      const resultPromise = new Promise((resolve, reject) => {
-        resolveDispatch = resolve;
-        rejectDispatch = reject;
-      });
-
-      const chain = previous.catch(() => {}).then(async () => {
-        try {
-          const result = await dispatchFn();
-          resolveDispatch(result);
-        } catch (err) {
-          rejectDispatch(err);
-        }
-      });
-
-      dispatchQueues.set(contextId, chain);
-
-      chain.finally(() => {
-        if (dispatchQueues.get(contextId) === chain) {
-          dispatchQueues.delete(contextId);
-        }
-      }).catch(() => {});
-
-      return resultPromise;
-    }
-
-    const order = [];
+    const queues = new Map<string, Promise<void>>();
+    const order: string[] = [];
 
     async function taskA() {
       order.push("A:start");
@@ -159,52 +63,23 @@ describe("per-contextId dispatch queue", () => {
 
     // Different contextIds — should run concurrently
     const [rA, rB] = await Promise.all([
-      enqueueDispatch("ctx-1", taskA),
-      enqueueDispatch("ctx-2", taskB),
+      enqueueDispatch(queues, "ctx-1", taskA),
+      enqueueDispatch(queues, "ctx-2", taskB),
     ]);
 
     assert.equal(rA, "A");
     assert.equal(rB, "B");
 
     // B should start before A ends (concurrent execution)
-    assert.ok(order.indexOf("B:start") < order.indexOf("A:end"),
-      `Expected B to start before A ends. Order: ${JSON.stringify(order)}`);
+    assert.ok(
+      order.indexOf("B:start") < order.indexOf("A:end"),
+      `Expected B to start before A ends. Order: ${JSON.stringify(order)}`,
+    );
   });
 
   it("does not poison the chain when a task fails", async () => {
-    const dispatchQueues = new Map();
-
-    function enqueueDispatch(contextId, dispatchFn) {
-      const previous = dispatchQueues.get(contextId) ?? Promise.resolve();
-
-      let resolveDispatch;
-      let rejectDispatch;
-      const resultPromise = new Promise((resolve, reject) => {
-        resolveDispatch = resolve;
-        rejectDispatch = reject;
-      });
-
-      const chain = previous.catch(() => {}).then(async () => {
-        try {
-          const result = await dispatchFn();
-          resolveDispatch(result);
-        } catch (err) {
-          rejectDispatch(err);
-        }
-      });
-
-      dispatchQueues.set(contextId, chain);
-
-      chain.finally(() => {
-        if (dispatchQueues.get(contextId) === chain) {
-          dispatchQueues.delete(contextId);
-        }
-      }).catch(() => {});
-
-      return resultPromise;
-    }
-
-    const order = [];
+    const queues = new Map<string, Promise<void>>();
+    const order: string[] = [];
 
     async function failingTask() {
       order.push("fail:start");
@@ -217,10 +92,24 @@ describe("per-contextId dispatch queue", () => {
     }
 
     // First task fails, second should still run
-    await assert.rejects(() => enqueueDispatch("ctx-1", failingTask), { message: "boom" });
-    const result = await enqueueDispatch("ctx-1", successTask);
+    await assert.rejects(() => enqueueDispatch(queues, "ctx-1", failingTask), {
+      message: "boom",
+    });
+    const result = await enqueueDispatch(queues, "ctx-1", successTask);
 
     assert.equal(result, "ok");
     assert.deepEqual(order, ["fail:start", "success:start"]);
+  });
+
+  it("cleans up queue entries after chain settles", async () => {
+    const queues = new Map<string, Promise<void>>();
+
+    await enqueueDispatch(queues, "ctx-cleanup", async () => "done");
+
+    // Allow microtask queue to flush (.finally() runs async)
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Entry should be removed after completion
+    assert.equal(queues.has("ctx-cleanup"), false);
   });
 });


### PR DESCRIPTION
## Problem

When two A2A tasks arrive with the same `contextId` in quick succession, the gateway dispatches both concurrently to the same OpenClaw session. This causes a race condition on the session `.jsonl` file, resulting in `EmbeddedAttemptSessionTakeoverError` for the second task.

Fixes #81

## Solution

Added a per-`contextId` dispatch queue (`dispatchQueues`) in `OpenClawAgentExecutor` that chains tasks sharing the same context so they are dispatched sequentially rather than concurrently.

Key design decisions per maintainer feedback:

1. **Failure isolation** — `previous.catch(() => {})` prevents one failed task from poisoning the chain for subsequent tasks
2. **Queue cleanup** — entries are removed via `.finally()` once the chain settles, preventing unbounded map growth
3. **Only dispatch is serialized** — the initial `working` status and SSE heartbeats are still published immediately, so queued tasks appear alive to clients while waiting for their turn

## Changes

- `src/executor.ts`: Added `dispatchQueues` map and `enqueueDispatch()` method; `execute()` now calls `enqueueDispatch()` instead of `dispatchViaGatewayRpc()` directly

## Testing

- TypeScript compiles cleanly (`tsc --noEmit`)
- Repro from issue: sending two messages with same contextId in quick succession should now queue the second dispatch until the first completes