### PR TITLE
fix: restore Node 22 lockfile compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,6 +1224,15 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/voice/node_modules/opusscript": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/opusscript/-/opusscript-0.0.8.tgz",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",


### PR DESCRIPTION
## Summary

- add the missing nested `opusscript@0.0.8` lockfile record required by `@discordjs/voice`
- restore reproducible `npm ci` installs with the repository's Node 22 runtime

Fixes #84.

## Proof

- old lock: `npm ci` fails with `Missing: opusscript@0.0.8 from lock file`
- updated lock: Node 22.22.2 / npm 10.9.7 clean install passes
- `npm test`: 513 passed, 0 failed
- `npm run build`
- `npm pack --dry-run`
- autoreview: no accepted/actionable findings

Local macOS install proof set `SHARP_IGNORE_GLOBAL_LIBVIPS=1` because Homebrew libvips 8.18 otherwise makes Sharp choose an unrelated source-build path.
