### PR TITLE
test: separate benchmark from default suite

### DIFF
--- a/benchmarks/benchmark.ts
+++ b/benchmarks/benchmark.ts
@@ -12,6 +12,7 @@ import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import http from "node:http";
 import dns from "node:dns";
 
@@ -60,13 +61,7 @@ interface BenchmarkResult {
 }
 
 const results: BenchmarkResult[] = [];
-const OUTPUT_PATH = path.join(
-  process.env.HOME!,
-  "Desktop",
-  "A2A-仿生研究",
-  "研究文档",
-  "06-benchmark-results.md",
-);
+const OUTPUT_PATH = fileURLToPath(new URL("../BENCHMARK.md", import.meta.url));
 
 const noopLog = () => {};
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build": "tsc",
     "prepack": "npm run build",
-    "test": "node --import tsx --test tests/*.test.ts"
+    "test": "node --import tsx --test tests/*.test.ts",
+    "benchmark": "node --import tsx --test benchmarks/benchmark.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",


### PR DESCRIPTION
## Summary

- move the bio-inspired benchmark out of `tests/*.test.ts`
- add an explicit `npm run benchmark` command
- write the generated report to the repository-root `BENCHMARK.md`
- keep the benchmark implementation and assertions intact

## Why

The default `npm test` command currently runs `tests/benchmark.test.ts`, which creates and overwrites a hard-coded report under the invoking user's `$HOME/Desktop` directory.

The benchmark is useful as an intentional project artifact, but it should not be coupled to the default test suite or silently modify a persistent user-owned path. This change makes benchmark execution explicit and places its generated report in a visible, reviewable repository location.

## Behavior

- `npm test` runs the regular test suite without running the benchmark or writing the benchmark report.
- `npm run benchmark` runs the existing benchmark suite and updates `BENCHMARK.md`.
- The existing benchmark assertions and console summary are preserved.

## Validation

- `npm run build`
- verified the default `tests/*.test.ts` glob no longer includes the benchmark
- verified the explicit benchmark command targets `benchmarks/benchmark.ts` and writes `BENCHMARK.md`

Fixes #87
